### PR TITLE
Block intl package updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,13 @@
       "schedule": [
         "before 6:00am every friday"
       ]
+    },
+    {
+      "description": "Dependencies whose updates shouldn't be done automatically",
+      "matchPackageNames": [
+        "intl"
+      ],
+      "enabled": false
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
The pull request blocks updates to the intl package. This project relies on the version of intl provided by the SDK, so updates should not be managed by Renovate.