### PR TITLE
Enhance item and font api to retrieve lazy objects

### DIFF
--- a/lib/api/api_service.dart
+++ b/lib/api/api_service.dart
@@ -2,10 +2,10 @@ import 'package:stelaris/api/api_client.dart';
 import 'package:stelaris/api/base_api.dart';
 import 'package:stelaris/api/client_api.dart';
 import 'package:stelaris/api/model/attribute_model.dart';
-import 'package:stelaris/api/model/font_model.dart';
-import 'package:stelaris/api/model/item_model.dart';
 import 'package:stelaris/api/model/notification_model.dart';
+import 'package:stelaris/api/service/font_api.dart';
 import 'package:stelaris/api/service/generate_api.dart';
+import 'package:stelaris/api/service/item_api.dart';
 import 'package:stelaris/env/environment.dart';
 
 /// The [ApiService] class contains all web services which are used in the app to communicate with the backend.
@@ -22,12 +22,7 @@ class ApiService {
 
   late final GenerateApi generateApi = GenerateApi(_generatorClient);
 
-  late final ClientAPI<ItemModel> itemApi = BaseApi(
-    apiClient: _apiClient,
-    endpoint: 'item',
-    fromJson: (p0) => ItemModel.fromJson(p0),
-    toJson: (model) => model.toJson(),
-  );
+  late final ItemAPI itemApi = ItemAPI(apiClient: _apiClient);
 
   late final ClientAPI<NotificationModel> notificationApi = BaseApi(
     apiClient: _apiClient,
@@ -36,12 +31,7 @@ class ApiService {
     toJson: (model) => model.toJson(),
   );
 
-  late final ClientAPI<FontModel> fontApi = BaseApi(
-    apiClient: _apiClient,
-    endpoint: 'font',
-    fromJson: (p0) => FontModel.fromJson(p0),
-    toJson: (model) => model.toJson(),
-  );
+  late final FontAPI fontApi = FontAPI(apiClient: _apiClient);
 
   late final ClientAPI<AttributeModel> attributeApi = BaseApi(
     apiClient: _apiClient,

--- a/lib/api/model/font/font_char_model.dart
+++ b/lib/api/model/font/font_char_model.dart
@@ -1,0 +1,19 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'font_char_model.freezed.dart';
+part 'font_char_model.g.dart';
+
+@freezed
+abstract class FontCharModel with _$FontCharModel {
+
+  const FontCharModel._(); // Add this private constructor
+
+  const factory FontCharModel({
+    required String id,
+    required List<String> chars,
+  }) = _FontCharModel;
+
+  factory FontCharModel.fromJson(Map<String, dynamic> json) =>
+      _$FontCharModelFromJson(json);
+
+}

--- a/lib/api/model/font/font_char_model.freezed.dart
+++ b/lib/api/model/font/font_char_model.freezed.dart
@@ -1,0 +1,286 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'font_char_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$FontCharModel {
+
+ String get id; List<String> get chars;
+/// Create a copy of FontCharModel
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$FontCharModelCopyWith<FontCharModel> get copyWith => _$FontCharModelCopyWithImpl<FontCharModel>(this as FontCharModel, _$identity);
+
+  /// Serializes this FontCharModel to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is FontCharModel&&(identical(other.id, id) || other.id == id)&&const DeepCollectionEquality().equals(other.chars, chars));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,const DeepCollectionEquality().hash(chars));
+
+@override
+String toString() {
+  return 'FontCharModel(id: $id, chars: $chars)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $FontCharModelCopyWith<$Res>  {
+  factory $FontCharModelCopyWith(FontCharModel value, $Res Function(FontCharModel) _then) = _$FontCharModelCopyWithImpl;
+@useResult
+$Res call({
+ String id, List<String> chars
+});
+
+
+
+
+}
+/// @nodoc
+class _$FontCharModelCopyWithImpl<$Res>
+    implements $FontCharModelCopyWith<$Res> {
+  _$FontCharModelCopyWithImpl(this._self, this._then);
+
+  final FontCharModel _self;
+  final $Res Function(FontCharModel) _then;
+
+/// Create a copy of FontCharModel
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? chars = null,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,chars: null == chars ? _self.chars : chars // ignore: cast_nullable_to_non_nullable
+as List<String>,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [FontCharModel].
+extension FontCharModelPatterns on FontCharModel {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _FontCharModel value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _FontCharModel() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _FontCharModel value)  $default,){
+final _that = this;
+switch (_that) {
+case _FontCharModel():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _FontCharModel value)?  $default,){
+final _that = this;
+switch (_that) {
+case _FontCharModel() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  List<String> chars)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _FontCharModel() when $default != null:
+return $default(_that.id,_that.chars);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  List<String> chars)  $default,) {final _that = this;
+switch (_that) {
+case _FontCharModel():
+return $default(_that.id,_that.chars);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  List<String> chars)?  $default,) {final _that = this;
+switch (_that) {
+case _FontCharModel() when $default != null:
+return $default(_that.id,_that.chars);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _FontCharModel extends FontCharModel {
+  const _FontCharModel({required this.id, required final  List<String> chars}): _chars = chars,super._();
+  factory _FontCharModel.fromJson(Map<String, dynamic> json) => _$FontCharModelFromJson(json);
+
+@override final  String id;
+ final  List<String> _chars;
+@override List<String> get chars {
+  if (_chars is EqualUnmodifiableListView) return _chars;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_chars);
+}
+
+
+/// Create a copy of FontCharModel
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$FontCharModelCopyWith<_FontCharModel> get copyWith => __$FontCharModelCopyWithImpl<_FontCharModel>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$FontCharModelToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _FontCharModel&&(identical(other.id, id) || other.id == id)&&const DeepCollectionEquality().equals(other._chars, _chars));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,const DeepCollectionEquality().hash(_chars));
+
+@override
+String toString() {
+  return 'FontCharModel(id: $id, chars: $chars)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$FontCharModelCopyWith<$Res> implements $FontCharModelCopyWith<$Res> {
+  factory _$FontCharModelCopyWith(_FontCharModel value, $Res Function(_FontCharModel) _then) = __$FontCharModelCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, List<String> chars
+});
+
+
+
+
+}
+/// @nodoc
+class __$FontCharModelCopyWithImpl<$Res>
+    implements _$FontCharModelCopyWith<$Res> {
+  __$FontCharModelCopyWithImpl(this._self, this._then);
+
+  final _FontCharModel _self;
+  final $Res Function(_FontCharModel) _then;
+
+/// Create a copy of FontCharModel
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? chars = null,}) {
+  return _then(_FontCharModel(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,chars: null == chars ? _self._chars : chars // ignore: cast_nullable_to_non_nullable
+as List<String>,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/api/model/font/font_char_model.g.dart
+++ b/lib/api/model/font/font_char_model.g.dart
@@ -1,0 +1,16 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'font_char_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_FontCharModel _$FontCharModelFromJson(Map<String, dynamic> json) =>
+    _FontCharModel(
+      id: json['id'] as String,
+      chars: (json['chars'] as List<dynamic>).map((e) => e as String).toList(),
+    );
+
+Map<String, dynamic> _$FontCharModelToJson(_FontCharModel instance) =>
+    <String, dynamic>{'id': instance.id, 'chars': instance.chars};

--- a/lib/api/model/item/item_enchantment_model.dart
+++ b/lib/api/model/item/item_enchantment_model.dart
@@ -1,0 +1,18 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'item_enchantment_model.g.dart';
+part 'item_enchantment_model.freezed.dart';
+
+@freezed
+abstract class ItemEnchantmentModel with _$ItemEnchantmentModel {
+
+  const ItemEnchantmentModel._();
+
+  const factory ItemEnchantmentModel({
+    required String id,
+    required Map<String, int> enchantments,
+  }) = _ItemEnchantmentModel;
+
+  factory ItemEnchantmentModel.fromJson(Map<String, dynamic> json) =>
+      _$ItemEnchantmentModelFromJson(json);
+}

--- a/lib/api/model/item/item_enchantment_model.freezed.dart
+++ b/lib/api/model/item/item_enchantment_model.freezed.dart
@@ -1,0 +1,286 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'item_enchantment_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ItemEnchantmentModel {
+
+ String get id; Map<String, int> get enchantments;
+/// Create a copy of ItemEnchantmentModel
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ItemEnchantmentModelCopyWith<ItemEnchantmentModel> get copyWith => _$ItemEnchantmentModelCopyWithImpl<ItemEnchantmentModel>(this as ItemEnchantmentModel, _$identity);
+
+  /// Serializes this ItemEnchantmentModel to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ItemEnchantmentModel&&(identical(other.id, id) || other.id == id)&&const DeepCollectionEquality().equals(other.enchantments, enchantments));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,const DeepCollectionEquality().hash(enchantments));
+
+@override
+String toString() {
+  return 'ItemEnchantmentModel(id: $id, enchantments: $enchantments)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ItemEnchantmentModelCopyWith<$Res>  {
+  factory $ItemEnchantmentModelCopyWith(ItemEnchantmentModel value, $Res Function(ItemEnchantmentModel) _then) = _$ItemEnchantmentModelCopyWithImpl;
+@useResult
+$Res call({
+ String id, Map<String, int> enchantments
+});
+
+
+
+
+}
+/// @nodoc
+class _$ItemEnchantmentModelCopyWithImpl<$Res>
+    implements $ItemEnchantmentModelCopyWith<$Res> {
+  _$ItemEnchantmentModelCopyWithImpl(this._self, this._then);
+
+  final ItemEnchantmentModel _self;
+  final $Res Function(ItemEnchantmentModel) _then;
+
+/// Create a copy of ItemEnchantmentModel
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? enchantments = null,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,enchantments: null == enchantments ? _self.enchantments : enchantments // ignore: cast_nullable_to_non_nullable
+as Map<String, int>,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [ItemEnchantmentModel].
+extension ItemEnchantmentModelPatterns on ItemEnchantmentModel {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _ItemEnchantmentModel value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _ItemEnchantmentModel() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _ItemEnchantmentModel value)  $default,){
+final _that = this;
+switch (_that) {
+case _ItemEnchantmentModel():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _ItemEnchantmentModel value)?  $default,){
+final _that = this;
+switch (_that) {
+case _ItemEnchantmentModel() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  Map<String, int> enchantments)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _ItemEnchantmentModel() when $default != null:
+return $default(_that.id,_that.enchantments);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  Map<String, int> enchantments)  $default,) {final _that = this;
+switch (_that) {
+case _ItemEnchantmentModel():
+return $default(_that.id,_that.enchantments);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  Map<String, int> enchantments)?  $default,) {final _that = this;
+switch (_that) {
+case _ItemEnchantmentModel() when $default != null:
+return $default(_that.id,_that.enchantments);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _ItemEnchantmentModel extends ItemEnchantmentModel {
+  const _ItemEnchantmentModel({required this.id, required final  Map<String, int> enchantments}): _enchantments = enchantments,super._();
+  factory _ItemEnchantmentModel.fromJson(Map<String, dynamic> json) => _$ItemEnchantmentModelFromJson(json);
+
+@override final  String id;
+ final  Map<String, int> _enchantments;
+@override Map<String, int> get enchantments {
+  if (_enchantments is EqualUnmodifiableMapView) return _enchantments;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(_enchantments);
+}
+
+
+/// Create a copy of ItemEnchantmentModel
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ItemEnchantmentModelCopyWith<_ItemEnchantmentModel> get copyWith => __$ItemEnchantmentModelCopyWithImpl<_ItemEnchantmentModel>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ItemEnchantmentModelToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ItemEnchantmentModel&&(identical(other.id, id) || other.id == id)&&const DeepCollectionEquality().equals(other._enchantments, _enchantments));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,const DeepCollectionEquality().hash(_enchantments));
+
+@override
+String toString() {
+  return 'ItemEnchantmentModel(id: $id, enchantments: $enchantments)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$ItemEnchantmentModelCopyWith<$Res> implements $ItemEnchantmentModelCopyWith<$Res> {
+  factory _$ItemEnchantmentModelCopyWith(_ItemEnchantmentModel value, $Res Function(_ItemEnchantmentModel) _then) = __$ItemEnchantmentModelCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, Map<String, int> enchantments
+});
+
+
+
+
+}
+/// @nodoc
+class __$ItemEnchantmentModelCopyWithImpl<$Res>
+    implements _$ItemEnchantmentModelCopyWith<$Res> {
+  __$ItemEnchantmentModelCopyWithImpl(this._self, this._then);
+
+  final _ItemEnchantmentModel _self;
+  final $Res Function(_ItemEnchantmentModel) _then;
+
+/// Create a copy of ItemEnchantmentModel
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? enchantments = null,}) {
+  return _then(_ItemEnchantmentModel(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,enchantments: null == enchantments ? _self._enchantments : enchantments // ignore: cast_nullable_to_non_nullable
+as Map<String, int>,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/api/model/item/item_enchantment_model.g.dart
+++ b/lib/api/model/item/item_enchantment_model.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'item_enchantment_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ItemEnchantmentModel _$ItemEnchantmentModelFromJson(
+  Map<String, dynamic> json,
+) => _ItemEnchantmentModel(
+  id: json['id'] as String,
+  enchantments: Map<String, int>.from(json['enchantments'] as Map),
+);
+
+Map<String, dynamic> _$ItemEnchantmentModelToJson(
+  _ItemEnchantmentModel instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'enchantments': instance.enchantments,
+};

--- a/lib/api/model/item/item_flag_model.dart
+++ b/lib/api/model/item/item_flag_model.dart
@@ -1,0 +1,18 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'item_flag_model.g.dart';
+part 'item_flag_model.freezed.dart';
+
+@freezed
+abstract class ItemFlagModel with _$ItemFlagModel {
+
+  const ItemFlagModel._();
+
+  const factory ItemFlagModel({
+    required String id,
+    required List<String> flags,
+  }) = _ItemFlagModel;
+
+  factory ItemFlagModel.fromJson(Map<String, dynamic> json) =>
+      _$ItemFlagModelFromJson(json);
+}

--- a/lib/api/model/item/item_flag_model.freezed.dart
+++ b/lib/api/model/item/item_flag_model.freezed.dart
@@ -1,0 +1,286 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'item_flag_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ItemFlagModel {
+
+ String get id; List<String> get flags;
+/// Create a copy of ItemFlagModel
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ItemFlagModelCopyWith<ItemFlagModel> get copyWith => _$ItemFlagModelCopyWithImpl<ItemFlagModel>(this as ItemFlagModel, _$identity);
+
+  /// Serializes this ItemFlagModel to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ItemFlagModel&&(identical(other.id, id) || other.id == id)&&const DeepCollectionEquality().equals(other.flags, flags));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,const DeepCollectionEquality().hash(flags));
+
+@override
+String toString() {
+  return 'ItemFlagModel(id: $id, flags: $flags)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ItemFlagModelCopyWith<$Res>  {
+  factory $ItemFlagModelCopyWith(ItemFlagModel value, $Res Function(ItemFlagModel) _then) = _$ItemFlagModelCopyWithImpl;
+@useResult
+$Res call({
+ String id, List<String> flags
+});
+
+
+
+
+}
+/// @nodoc
+class _$ItemFlagModelCopyWithImpl<$Res>
+    implements $ItemFlagModelCopyWith<$Res> {
+  _$ItemFlagModelCopyWithImpl(this._self, this._then);
+
+  final ItemFlagModel _self;
+  final $Res Function(ItemFlagModel) _then;
+
+/// Create a copy of ItemFlagModel
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? flags = null,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,flags: null == flags ? _self.flags : flags // ignore: cast_nullable_to_non_nullable
+as List<String>,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [ItemFlagModel].
+extension ItemFlagModelPatterns on ItemFlagModel {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _ItemFlagModel value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _ItemFlagModel() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _ItemFlagModel value)  $default,){
+final _that = this;
+switch (_that) {
+case _ItemFlagModel():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _ItemFlagModel value)?  $default,){
+final _that = this;
+switch (_that) {
+case _ItemFlagModel() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  List<String> flags)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _ItemFlagModel() when $default != null:
+return $default(_that.id,_that.flags);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  List<String> flags)  $default,) {final _that = this;
+switch (_that) {
+case _ItemFlagModel():
+return $default(_that.id,_that.flags);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  List<String> flags)?  $default,) {final _that = this;
+switch (_that) {
+case _ItemFlagModel() when $default != null:
+return $default(_that.id,_that.flags);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _ItemFlagModel extends ItemFlagModel {
+  const _ItemFlagModel({required this.id, required final  List<String> flags}): _flags = flags,super._();
+  factory _ItemFlagModel.fromJson(Map<String, dynamic> json) => _$ItemFlagModelFromJson(json);
+
+@override final  String id;
+ final  List<String> _flags;
+@override List<String> get flags {
+  if (_flags is EqualUnmodifiableListView) return _flags;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_flags);
+}
+
+
+/// Create a copy of ItemFlagModel
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ItemFlagModelCopyWith<_ItemFlagModel> get copyWith => __$ItemFlagModelCopyWithImpl<_ItemFlagModel>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ItemFlagModelToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ItemFlagModel&&(identical(other.id, id) || other.id == id)&&const DeepCollectionEquality().equals(other._flags, _flags));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,const DeepCollectionEquality().hash(_flags));
+
+@override
+String toString() {
+  return 'ItemFlagModel(id: $id, flags: $flags)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$ItemFlagModelCopyWith<$Res> implements $ItemFlagModelCopyWith<$Res> {
+  factory _$ItemFlagModelCopyWith(_ItemFlagModel value, $Res Function(_ItemFlagModel) _then) = __$ItemFlagModelCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, List<String> flags
+});
+
+
+
+
+}
+/// @nodoc
+class __$ItemFlagModelCopyWithImpl<$Res>
+    implements _$ItemFlagModelCopyWith<$Res> {
+  __$ItemFlagModelCopyWithImpl(this._self, this._then);
+
+  final _ItemFlagModel _self;
+  final $Res Function(_ItemFlagModel) _then;
+
+/// Create a copy of ItemFlagModel
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? flags = null,}) {
+  return _then(_ItemFlagModel(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,flags: null == flags ? _self._flags : flags // ignore: cast_nullable_to_non_nullable
+as List<String>,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/api/model/item/item_flag_model.g.dart
+++ b/lib/api/model/item/item_flag_model.g.dart
@@ -1,0 +1,16 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'item_flag_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ItemFlagModel _$ItemFlagModelFromJson(Map<String, dynamic> json) =>
+    _ItemFlagModel(
+      id: json['id'] as String,
+      flags: (json['flags'] as List<dynamic>).map((e) => e as String).toList(),
+    );
+
+Map<String, dynamic> _$ItemFlagModelToJson(_ItemFlagModel instance) =>
+    <String, dynamic>{'id': instance.id, 'flags': instance.flags};

--- a/lib/api/model/item/item_lore_model.dart
+++ b/lib/api/model/item/item_lore_model.dart
@@ -1,0 +1,18 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'item_lore_model.freezed.dart';
+part 'item_lore_model.g.dart';
+
+@freezed
+abstract class ItemLoreModel with _$ItemLoreModel {
+
+  const ItemLoreModel._();
+
+  const factory ItemLoreModel({
+    required String id,
+    required Map<String, int> enchantments,
+  }) = _ItemLoreModel;
+
+  factory ItemLoreModel.fromJson(Map<String, dynamic> json) =>
+      _$ItemLoreModelFromJson(json);
+}

--- a/lib/api/model/item/item_lore_model.freezed.dart
+++ b/lib/api/model/item/item_lore_model.freezed.dart
@@ -1,0 +1,286 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'item_lore_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ItemLoreModel {
+
+ String get id; Map<String, int> get enchantments;
+/// Create a copy of ItemLoreModel
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ItemLoreModelCopyWith<ItemLoreModel> get copyWith => _$ItemLoreModelCopyWithImpl<ItemLoreModel>(this as ItemLoreModel, _$identity);
+
+  /// Serializes this ItemLoreModel to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ItemLoreModel&&(identical(other.id, id) || other.id == id)&&const DeepCollectionEquality().equals(other.enchantments, enchantments));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,const DeepCollectionEquality().hash(enchantments));
+
+@override
+String toString() {
+  return 'ItemLoreModel(id: $id, enchantments: $enchantments)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ItemLoreModelCopyWith<$Res>  {
+  factory $ItemLoreModelCopyWith(ItemLoreModel value, $Res Function(ItemLoreModel) _then) = _$ItemLoreModelCopyWithImpl;
+@useResult
+$Res call({
+ String id, Map<String, int> enchantments
+});
+
+
+
+
+}
+/// @nodoc
+class _$ItemLoreModelCopyWithImpl<$Res>
+    implements $ItemLoreModelCopyWith<$Res> {
+  _$ItemLoreModelCopyWithImpl(this._self, this._then);
+
+  final ItemLoreModel _self;
+  final $Res Function(ItemLoreModel) _then;
+
+/// Create a copy of ItemLoreModel
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? enchantments = null,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,enchantments: null == enchantments ? _self.enchantments : enchantments // ignore: cast_nullable_to_non_nullable
+as Map<String, int>,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [ItemLoreModel].
+extension ItemLoreModelPatterns on ItemLoreModel {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _ItemLoreModel value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _ItemLoreModel() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _ItemLoreModel value)  $default,){
+final _that = this;
+switch (_that) {
+case _ItemLoreModel():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _ItemLoreModel value)?  $default,){
+final _that = this;
+switch (_that) {
+case _ItemLoreModel() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  Map<String, int> enchantments)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _ItemLoreModel() when $default != null:
+return $default(_that.id,_that.enchantments);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  Map<String, int> enchantments)  $default,) {final _that = this;
+switch (_that) {
+case _ItemLoreModel():
+return $default(_that.id,_that.enchantments);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  Map<String, int> enchantments)?  $default,) {final _that = this;
+switch (_that) {
+case _ItemLoreModel() when $default != null:
+return $default(_that.id,_that.enchantments);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _ItemLoreModel extends ItemLoreModel {
+  const _ItemLoreModel({required this.id, required final  Map<String, int> enchantments}): _enchantments = enchantments,super._();
+  factory _ItemLoreModel.fromJson(Map<String, dynamic> json) => _$ItemLoreModelFromJson(json);
+
+@override final  String id;
+ final  Map<String, int> _enchantments;
+@override Map<String, int> get enchantments {
+  if (_enchantments is EqualUnmodifiableMapView) return _enchantments;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(_enchantments);
+}
+
+
+/// Create a copy of ItemLoreModel
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ItemLoreModelCopyWith<_ItemLoreModel> get copyWith => __$ItemLoreModelCopyWithImpl<_ItemLoreModel>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ItemLoreModelToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ItemLoreModel&&(identical(other.id, id) || other.id == id)&&const DeepCollectionEquality().equals(other._enchantments, _enchantments));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,const DeepCollectionEquality().hash(_enchantments));
+
+@override
+String toString() {
+  return 'ItemLoreModel(id: $id, enchantments: $enchantments)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$ItemLoreModelCopyWith<$Res> implements $ItemLoreModelCopyWith<$Res> {
+  factory _$ItemLoreModelCopyWith(_ItemLoreModel value, $Res Function(_ItemLoreModel) _then) = __$ItemLoreModelCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, Map<String, int> enchantments
+});
+
+
+
+
+}
+/// @nodoc
+class __$ItemLoreModelCopyWithImpl<$Res>
+    implements _$ItemLoreModelCopyWith<$Res> {
+  __$ItemLoreModelCopyWithImpl(this._self, this._then);
+
+  final _ItemLoreModel _self;
+  final $Res Function(_ItemLoreModel) _then;
+
+/// Create a copy of ItemLoreModel
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? enchantments = null,}) {
+  return _then(_ItemLoreModel(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,enchantments: null == enchantments ? _self._enchantments : enchantments // ignore: cast_nullable_to_non_nullable
+as Map<String, int>,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/api/model/item/item_lore_model.g.dart
+++ b/lib/api/model/item/item_lore_model.g.dart
@@ -1,0 +1,16 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'item_lore_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ItemLoreModel _$ItemLoreModelFromJson(Map<String, dynamic> json) =>
+    _ItemLoreModel(
+      id: json['id'] as String,
+      enchantments: Map<String, int>.from(json['enchantments'] as Map),
+    );
+
+Map<String, dynamic> _$ItemLoreModelToJson(_ItemLoreModel instance) =>
+    <String, dynamic>{'id': instance.id, 'enchantments': instance.enchantments};

--- a/lib/api/service/font_api.dart
+++ b/lib/api/service/font_api.dart
@@ -1,0 +1,22 @@
+import 'package:stelaris/api/base_api.dart';
+import 'package:stelaris/api/model/font/font_char_model.dart';
+import 'package:stelaris/api/model/font_model.dart';
+
+class FontAPI extends BaseApi<FontModel> {
+  FontAPI({required super.apiClient})
+    : super(
+        endpoint: 'font',
+        fromJson: (p0) => FontModel.fromJson(p0),
+        toJson: (model) => model.toJson(),
+      );
+
+  /// Fetches the character set for a specific font by its ID.
+  /// [id] is the unique identifier of the font.
+  /// Returns a [FontCharModel] containing the character set.
+  Future<FontCharModel> getChars(String id) async {
+    final baseUri = Uri.parse(apiClient.baseUrl);
+    final uri = baseUri.replace(path: '${baseUri.path}/$endpoint/chars/$id');
+    final result = await apiClient.dio.getUri(uri);
+    return FontCharModel.fromJson(result.data!);
+  }
+}

--- a/lib/api/service/item_api.dart
+++ b/lib/api/service/item_api.dart
@@ -1,0 +1,13 @@
+import 'package:stelaris/api/base_api.dart';
+import 'package:stelaris/api/model/item_model.dart';
+
+class ItemAPI extends BaseApi<ItemModel> {
+
+  ItemAPI({required super.apiClient})
+      : super(
+    endpoint: 'item',
+    fromJson: (p0) => ItemModel.fromJson(p0),
+    toJson: (model) => model.toJson(),
+  );
+
+}

--- a/lib/api/service/item_api.dart
+++ b/lib/api/service/item_api.dart
@@ -1,4 +1,7 @@
 import 'package:stelaris/api/base_api.dart';
+import 'package:stelaris/api/model/item/item_enchantment_model.dart';
+import 'package:stelaris/api/model/item/item_flag_model.dart';
+import 'package:stelaris/api/model/item/item_lore_model.dart';
 import 'package:stelaris/api/model/item_model.dart';
 
 class ItemAPI extends BaseApi<ItemModel> {
@@ -10,4 +13,24 @@ class ItemAPI extends BaseApi<ItemModel> {
     toJson: (model) => model.toJson(),
   );
 
+  Future<ItemEnchantmentModel> getEnchantments(String id) async {
+    final baseUri = Uri.parse(apiClient.baseUrl);
+    final uri = baseUri.replace(path: '${baseUri.path}/$endpoint/enchantments/$id');
+    final result = await apiClient.dio.getUri(uri);
+    return ItemEnchantmentModel.fromJson(result.data!);
+  }
+
+  Future<ItemLoreModel> getLore(String id) async {
+    final baseUri = Uri.parse(apiClient.baseUrl);
+    final uri = baseUri.replace(path: '${baseUri.path}/$endpoint/lore/$id');
+    final result = await apiClient.dio.getUri(uri);
+    return ItemLoreModel.fromJson(result.data!);
+  }
+
+  Future<ItemFlagModel> getFlags(String id) async {
+    final baseUri = Uri.parse(apiClient.baseUrl);
+    final uri = baseUri.replace(path: '${baseUri.path}/$endpoint/flags/$id');
+    final result = await apiClient.dio.getUri(uri);
+    return ItemFlagModel.fromJson(result.data!);
+  }
 }


### PR DESCRIPTION
## Proposed changes

Some data entries in the `ItemModel` or `FontModel` are element collections, which are lazy by default.  
This means that when a request is made, those collections may return `null`.  The UI requires certain models and endpoints to communicate with the backend in order to load this lazy data at a later point.  This pull request introduces the necessary changes to support that behavior.


## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)