### PR TITLE
Migrate widgets to non-deprecated constructors

### DIFF
--- a/lib/feature/base/cards/dropdown_card.dart
+++ b/lib/feature/base/cards/dropdown_card.dart
@@ -55,7 +55,7 @@ class _DropdownCardState<E, T> extends State<DropdownCard<E, T>> {
                   key: widget.formKey,
                   child: DropdownButtonFormField<E>(
                     items: widget.items,
-                    value: widget.defaultValue(widget.currentValue),
+                    initialValue: widget.defaultValue(widget.currentValue),
                     onChanged: (E? value) {
                       if (value == null) return;
                       setState(() => widget.valueUpdate(value));

--- a/lib/feature/build/parts/download_selection.dart
+++ b/lib/feature/build/parts/download_selection.dart
@@ -54,7 +54,7 @@ class _DownloadSelectionState extends State<DownloadSelection> {
             width: 300,
             child: DropdownButtonFormField<String>(
               items: widget.branches,
-              value: defaultValue,
+              initialValue: defaultValue,
               onChanged: (String? value) {
                 if (value == null) return;
                 defaultValue = value;

--- a/lib/feature/build/version_group_selection.dart
+++ b/lib/feature/build/version_group_selection.dart
@@ -17,27 +17,28 @@ class _VersionGroupSelectionState extends State<VersionGroupSelection> {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
-        RadioListTile(
-          title: Text(VersionPart.major.description),
-          value: VersionPart.major,
-          groupValue: _selectedPart,
-          onChanged: (VersionPart? value) => _updateGroupValue(value ?? VersionPart.major),
-        ),
-        RadioListTile(
-          title: Text(VersionPart.minor.description),
-          value: VersionPart.minor,
-          groupValue: _selectedPart,
-          onChanged: (VersionPart? value) => _updateGroupValue(value ?? VersionPart.minor),
-        ),
-        RadioListTile(
-          title: Text(VersionPart.patch.description),
-          value: VersionPart.patch,
-          groupValue: _selectedPart,
-          onChanged: (VersionPart? value) => _updateGroupValue(value ?? VersionPart.patch),
-        ),
-      ],
+    return RadioGroup(
+      groupValue: _selectedPart,
+      onChanged: (VersionPart? value) {
+        if (value == null) return;
+        _updateGroupValue(value);
+      },
+      child: Column(
+        children: [
+          RadioListTile(
+            title: Text(VersionPart.major.description),
+            value: VersionPart.major,
+          ),
+          RadioListTile(
+            title: Text(VersionPart.minor.description),
+            value: VersionPart.minor,
+          ),
+          RadioListTile(
+            title: Text(VersionPart.patch.description),
+            value: VersionPart.patch,
+          ),
+        ],
+      ),
     );
   }
 

--- a/lib/feature/dialogs/item_enchantments_dialog.dart
+++ b/lib/feature/dialogs/item_enchantments_dialog.dart
@@ -61,7 +61,7 @@ class _ItemEnchantmentAddDialogState extends State<ItemEnchantmentAddDialog>
         horizontalSpacing10,
         DropdownButtonFormField<Enchantment?>(
           autofocus: true,
-          value: _selected.value,
+          initialValue: _selected.value,
           items: enchantments,
           onChanged: (value) {
             _selected.value = value;


### PR DESCRIPTION
## Proposed changes

Some Flutter widgets retrieved deprecation warnings on their constructor parameter level. To avoid future issues, this pull request migrates them to the updated constructor usage.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)