### PR TITLE
Disable BuildDrawer integration

### DIFF
--- a/lib/feature/base/base_page.dart
+++ b/lib/feature/base/base_page.dart
@@ -42,7 +42,7 @@ class BasePage extends StatelessWidget {
           Expanded(child: child),
         ],
       ),
-      endDrawer: const BuildDrawer(),
+      //endDrawer: const BuildDrawer(),
     );
   }
 }


### PR DESCRIPTION
## Proposed changes

We are currently stabilizing the development of the frontend project **Stelaris** and the backend project **Vulpes-Backend** to establish a solid foundation for future testing.

To avoid a slow down the process and potential issues, this pull request **temporarily disables** the usage of the `BuildDrawer` widget, which serves as the entry point for generating and downloading a Vulpes instance.

The widget will be re-enabled once the corresponding generation backend has been updated.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)