### PR TITLE
Add FontFace tab and improve InputCard organization in FontFeature

### DIFF
--- a/lib/feature/font/face/font_face_page.dart
+++ b/lib/feature/font/face/font_face_page.dart
@@ -1,0 +1,151 @@
+import 'package:async_redux/async_redux.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:stelaris/api/state/actions/font_actions.dart';
+import 'package:stelaris/api/state/app_state.dart';
+import 'package:stelaris/api/state/factory/font/select_font_vm.dart';
+import 'package:stelaris/feature/base/button/positioned_save_button.dart';
+import 'package:stelaris/feature/base/cards/text_input_card.dart';
+import 'package:stelaris/util/constants.dart';
+import 'package:stelaris/util/l10n_ext.dart';
+
+class FontFacePage extends StatefulWidget {
+  const FontFacePage({super.key});
+
+  @override
+  State<FontFacePage> createState() => _FontFacePageState();
+}
+
+class _FontFacePageState extends State<FontFacePage> {
+  final ScrollController _scrollController = ScrollController();
+  final GlobalKey<FormState> _key = GlobalKey<FormState>();
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return StoreConnector<AppState, SelectedFontView>(
+      vm: () => SelectedFontFactory(),
+      builder: (context, vm) {
+        return Form(
+          key: _key,
+          autovalidateMode: AutovalidateMode.onUserInteraction,
+          child: Stack(
+            children: [
+              Positioned.fill(
+                child: AnimatedOpacity(
+                  duration: const Duration(milliseconds: 300),
+                  opacity: 1,
+                  child: LayoutBuilder(
+                    builder: (context, constraints) {
+                      return Scrollbar(
+                        controller: _scrollController,
+                        thumbVisibility: true,
+                        trackVisibility: true,
+                        child: SingleChildScrollView(
+                          controller: _scrollController,
+                          child: Padding(
+                            padding: const EdgeInsets.all(16),
+                            child: Wrap(
+                              spacing: 16,
+                              runSpacing: 16,
+                              children: [
+                                TextInputCard<String>(
+                                  display: 'Texture Path',
+                                  currentValue:
+                                      vm.selected.texturePath ?? emptyString,
+                                  formatter: [
+                                    FilteringTextInputFormatter.allow(
+                                      stringPattern,
+                                    ),
+                                  ],
+                                  valueUpdate: (value) {
+                                    if (value == vm.selected.texturePath) {
+                                      return;
+                                    }
+                                    final oldModel = vm.selected;
+                                    final newEntry = oldModel.copyWith(
+                                      texturePath: value,
+                                    );
+                                    context.dispatch(
+                                      UpdateFontAction(newEntry),
+                                    );
+                                  },
+                                ),
+                                TextInputCard<int>(
+                                  tooltipMessage: context.l10n.tooltip_ascent,
+                                  display: context.l10n.card_ascent,
+                                  currentValue: vm.selected.ascent.toString(),
+                                  valueUpdate: (value) {
+                                    final parsedValue =
+                                        int.tryParse(value) ?? 0;
+                                    if (parsedValue == vm.selected.ascent) {
+                                      return;
+                                    }
+                                    final oldModel = vm.selected;
+                                    final newEntry = oldModel.copyWith(
+                                      ascent: parsedValue,
+                                    );
+                                    context.dispatch(
+                                      UpdateFontAction(newEntry),
+                                    );
+                                  },
+                                  inputType: numberInput,
+                                  formatter: [
+                                    FilteringTextInputFormatter.allow(
+                                      fontNumberPattern,
+                                    ),
+                                  ],
+                                ),
+                                TextInputCard<int>(
+                                  tooltipMessage: context.l10n.tooltip_height,
+                                  display: context.l10n.card_height,
+                                  currentValue: vm.selected.height.toString(),
+                                  valueUpdate: (value) {
+                                    final parsedValue =
+                                        int.tryParse(value) ?? 0;
+                                    if (parsedValue == vm.selected.height) {
+                                      return;
+                                    }
+                                    final oldModel = vm.selected;
+                                    final newEntry = oldModel.copyWith(
+                                      height: parsedValue,
+                                    );
+                                    context.dispatch(
+                                      UpdateFontAction(newEntry),
+                                    );
+                                  },
+                                  inputType: numberInput,
+                                  formatter: [
+                                    FilteringTextInputFormatter.allow(
+                                      fontNumberPattern,
+                                    ),
+                                  ],
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              ),
+              PositionedSaveButton.standard(
+                callback: () {
+                  if (_key.currentState?.validate() ?? false) {
+                    context.dispatch(FontDatabaseUpdate());
+                  }
+                },
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/feature/font/font_general_page.dart
+++ b/lib/feature/font/font_general_page.dart
@@ -6,14 +6,11 @@ import 'package:stelaris/api/state/app_state.dart';
 import 'package:stelaris/api/state/factory/font/selected_font_state.dart';
 import 'package:stelaris/feature/base/button/positioned_save_button.dart';
 import 'package:stelaris/feature/base/cards/text_input_card.dart';
-import 'package:stelaris/util/l10n_ext.dart';
 import 'package:stelaris/util/constants.dart';
 import 'package:stelaris/util/functions.dart';
 
 class FontGeneralPage extends StatefulWidget {
-  const FontGeneralPage({required this.formKey, super.key});
-
-  final GlobalKey<FormState> formKey;
+  const FontGeneralPage({super.key});
 
   @override
   State<FontGeneralPage> createState() => _FontGeneralPageState();
@@ -22,6 +19,8 @@ class FontGeneralPage extends StatefulWidget {
 class _FontGeneralPageState extends State<FontGeneralPage> {
   /// Scroll controller for the scrollable content
   final ScrollController _scrollController = ScrollController();
+  final GlobalKey<FormState> _key = GlobalKey<FormState>();
+
 
   @override
   void dispose() {
@@ -35,7 +34,7 @@ class _FontGeneralPageState extends State<FontGeneralPage> {
       vm: () => SelectedFontFactory(),
       builder: (context, vm) {
         return Form(
-          key: widget.formKey,
+          key: _key,
           autovalidateMode: AutovalidateMode.onUserInteraction,
           child: Stack(
             children: [
@@ -109,28 +108,6 @@ class _FontGeneralPageState extends State<FontGeneralPage> {
                                   },
                                 ),
                                 TextInputCard<String>(
-                                  display: 'Texture Path',
-                                  currentValue:
-                                  vm.selected.texturePath ?? emptyString,
-                                  formatter: [
-                                    FilteringTextInputFormatter.allow(
-                                      stringPattern,
-                                    ),
-                                  ],
-                                  valueUpdate: (value) {
-                                    if (value == vm.selected.texturePath) {
-                                      return;
-                                    }
-                                    final oldModel = vm.selected;
-                                    final newEntry = oldModel.copyWith(
-                                      texturePath: value,
-                                    );
-                                    context.dispatch(
-                                      UpdateFontAction(newEntry),
-                                    );
-                                  },
-                                ),
-                                TextInputCard<String>(
                                   display: 'Comment',
                                   currentValue:
                                   vm.selected.comment ?? emptyString,
@@ -152,58 +129,6 @@ class _FontGeneralPageState extends State<FontGeneralPage> {
                                     );
                                   },
                                 ),
-                                TextInputCard<int>(
-                                  tooltipMessage: context.l10n.tooltip_ascent,
-                                  display: context.l10n.card_ascent,
-                                  currentValue:
-                                      vm.selected.ascent.toString(),
-                                  valueUpdate: (value) {
-                                    final parsedValue =
-                                        int.tryParse(value) ?? 0;
-                                    if (parsedValue == vm.selected.ascent) {
-                                      return;
-                                    }
-                                    final oldModel = vm.selected;
-                                    final newEntry = oldModel.copyWith(
-                                      ascent: parsedValue,
-                                    );
-                                    context.dispatch(
-                                      UpdateFontAction(newEntry),
-                                    );
-                                  },
-                                  inputType: numberInput,
-                                  formatter: [
-                                    FilteringTextInputFormatter.allow(
-                                      fontNumberPattern,
-                                    ),
-                                  ],
-                                ),
-                                TextInputCard<int>(
-                                  tooltipMessage: context.l10n.tooltip_height,
-                                  display: context.l10n.card_height,
-                                  currentValue:
-                                      vm.selected.height.toString(),
-                                  valueUpdate: (value) {
-                                    final parsedValue =
-                                        int.tryParse(value) ?? 0;
-                                    if (parsedValue == vm.selected.height) {
-                                      return;
-                                    }
-                                    final oldModel = vm.selected;
-                                    final newEntry = oldModel.copyWith(
-                                      height: parsedValue,
-                                    );
-                                    context.dispatch(
-                                      UpdateFontAction(newEntry),
-                                    );
-                                  },
-                                  inputType: numberInput,
-                                  formatter: [
-                                    FilteringTextInputFormatter.allow(
-                                      fontNumberPattern,
-                                    ),
-                                  ],
-                                ),
                               ],
                             ),
                           ),
@@ -215,7 +140,7 @@ class _FontGeneralPageState extends State<FontGeneralPage> {
               ),
               PositionedSaveButton.standard(
                 callback: () {
-                  if (widget.formKey.currentState?.validate() ?? false) {
+                  if (_key.currentState?.validate() ?? false) {
                     context.dispatch(FontDatabaseUpdate());
                   }
                 },

--- a/lib/feature/font/font_page.dart
+++ b/lib/feature/font/font_page.dart
@@ -10,6 +10,7 @@ import 'package:stelaris/feature/base/model_text.dart';
 import 'package:stelaris/feature/base/paginated_model_view_tab.dart';
 import 'package:stelaris/feature/dialogs/entry_update_dialog.dart';
 import 'package:stelaris/feature/font/chars/char_card.dart';
+import 'package:stelaris/feature/font/face/font_face_page.dart';
 import 'package:stelaris/feature/font/font_general_page.dart';
 import 'package:stelaris/util/constants.dart';
 import 'package:stelaris/util/functions.dart';
@@ -77,7 +78,11 @@ class FontPage extends StatelessWidget {
   }
 
   List<Tab> _getTabs() {
-    return [const Tab(child: Text('General')), const Tab(child: Text('Chars'))];
+    return [
+      const Tab(child: Text('General')),
+      const Tab(child: Text('FontFace')),
+      const Tab(child: Text('Chars')),
+    ];
   }
 
   /// Maps the given [FontModel] to the right widget.
@@ -91,7 +96,8 @@ class FontPage extends StatelessWidget {
       );
     }
     return switch (value) {
-      'General' => FontGeneralPage(formKey: GlobalKey<FormState>()),
+      'General' => const FontGeneralPage(),
+      'FontFace' => const FontFacePage(),
       'Chars' => const CharCard(),
       _ => const Placeholder(), // optional default case
     };


### PR DESCRIPTION
## Proposed changes

This pull request refines the grouping of `InputCard` widgets in the **FontFeature**.  
A new tab named **FontFace** has been added, which includes the `ascent`, `height`, and `texturePath` input fields.

### Before
<img width="2126" height="632" alt="Old tab layout and grouping" src="https://github.com/user-attachments/assets/e27ad62b-3fc7-4e4d-84f3-de16b2370f9c" />

### After
<img width="1239" height="558" alt="New tab layout" src="https://github.com/user-attachments/assets/5a9d7e28-d2c1-4c27-ac8c-85519aa5ad96" />


## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [ ] I have read the CONTRIBUTING.md
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...