### PR TITLE
Align used padding for pagination view with and without tabs

### DIFF
--- a/lib/feature/base/paginated_model_list.dart
+++ b/lib/feature/base/paginated_model_list.dart
@@ -89,21 +89,24 @@ class _PaginatedModelListState<E extends DataModel>
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      width: PaginatedModelList._listWidth,
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Expanded(
-            child: _buildListView(),
-          ),
-          verticalSpacing10,
-          Padding(
-            padding: const EdgeInsets.only(
-                bottom: PaginatedModelList._bottomPadding),
-            child: AddButton(openFunction: widget.openFunction),
-          )
-        ],
+    return Padding(
+      padding: const EdgeInsets.only(top: 10),
+      child: SizedBox(
+        width: PaginatedModelList._listWidth,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Expanded(
+              child: _buildListView(),
+            ),
+            verticalSpacing10,
+            Padding(
+              padding: const EdgeInsets.only(
+                  bottom: PaginatedModelList._bottomPadding),
+              child: AddButton(openFunction: widget.openFunction),
+            )
+          ],
+        ),
       ),
     );
   }

--- a/lib/feature/base/paginated_model_view_tab.dart
+++ b/lib/feature/base/paginated_model_view_tab.dart
@@ -51,36 +51,33 @@ class PaginatedBaseModelViewTabs<E extends DataModel> extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.all(20),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          PaginatedModelList<E>(
-            mapToDataModelItem: mapToDataModelItem,
-            selectedItem: selectedItem,
-            openFunction: openFunction,
-            mapToDeleteDialog: mapToDeleteDialog,
-            mapToDeleteSuccessfully: mapToDeleteSuccessfully,
-            callFunction: callFunction,
-            models: models,
-            compareFunction: compareFunction,
-            onLoadMore: onLoadMore,
-            hasMore: hasMore,
-            isLoadingMore: isLoadingMore,
-          ),
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        PaginatedModelList<E>(
+          mapToDataModelItem: mapToDataModelItem,
+          selectedItem: selectedItem,
+          openFunction: openFunction,
+          mapToDeleteDialog: mapToDeleteDialog,
+          mapToDeleteSuccessfully: mapToDeleteSuccessfully,
+          callFunction: callFunction,
+          models: models,
+          compareFunction: compareFunction,
+          onLoadMore: onLoadMore,
+          hasMore: hasMore,
+          isLoadingMore: isLoadingMore,
+        ),
 
-          verticalSpacing10,
-          Expanded(
-            child: ModelContentTabPage<E>(
-              selectedItem: selectedItem,
-              page: page,
-              tabPages: tabPages,
-              tabs: tabs,
-            ),
+        verticalSpacing10,
+        Expanded(
+          child: ModelContentTabPage<E>(
+            selectedItem: selectedItem,
+            page: page,
+            tabPages: tabPages,
+            tabs: tabs,
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
## Proposed changes

The current implementation of the model list with and without tabs uses different paddings. This causes the “Add” button and the displayed content to jump. This pull request fixes that issue by aligning the paddings.

Alignment after the change:

<img width="1674" height="677" alt="image" src="https://github.com/user-attachments/assets/c6a7d008-e15e-4b10-972e-6d4720d01a73" />

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)