### PR TITLE
Improve level display

### DIFF
--- a/lib/feature/item/enchantment/enchantment_item.dart
+++ b/lib/feature/item/enchantment/enchantment_item.dart
@@ -62,16 +62,7 @@ class _EnchantmentItemState extends State<EnchantmentItem> {
               fontWeight: FontWeight.bold,
             ),
           ),
-          subtitle: Row(
-            children: [
-              const Text('Level: '),
-              Text(widget.dto.level.toString()),
-              Text(
-                ' / ${widget.enchantment.maxLevel}',
-                style: theme.textTheme.bodySmall,
-              ),
-            ],
-          ),
+          subtitle: _getEnchantmentSubTitle(theme, widget.dto),
           trailing: EntryActions(
             onEdit: () => _showUpdateDialog(widget.enchantment, widget.dto),
             onDelete: () => _showDeleteDialog(widget.dto),
@@ -81,10 +72,33 @@ class _EnchantmentItemState extends State<EnchantmentItem> {
     );
   }
 
+  /// Applies the right sub title [Widget] based on the [ItemEnchantmentDto.unsafe] flag.
+  /// [theme] the current [ThemeData] to get some values from it
+  /// [dto] the [ItemEnchantmentDto] to build the widget
+  /// Returns the concrete [Widget] that displays the data
+  Widget _getEnchantmentSubTitle(ThemeData theme, ItemEnchantmentDto dto) {
+    if (dto.unsafe) {
+      return Row(children: [const Text('Level: '), Text(dto.level.toString())]);
+    }
+    return Row(
+      children: [
+        const Text('Level: '),
+        Text(widget.dto.level.toString()),
+        Text(
+          ' / ${widget.enchantment.maxLevel}',
+          style: theme.textTheme.bodySmall,
+        ),
+      ],
+    );
+  }
+
   void _showUpdateDialog(Enchantment enchantment, ItemEnchantmentDto dto) {
-    showDialog(context: context, builder: (BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
         return ItemEnchantmentUpdateDialog(enchantment: enchantment, dto: dto);
-    });
+      },
+    );
   }
 
   void _showDeleteDialog(ItemEnchantmentDto dto) {


### PR DESCRIPTION
## Proposed changes

Due to the merge of #72, the display of the current level of an `Enchantment` requires an overhaul. If an enchantment has the unsafe option set to true, the level information should not be capped by any maximum value. This pull request improves that part.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)