### PR TITLE
Fix edit logic for font string entries

### DIFF
--- a/lib/api/state/actions/font/font_string_actions.dart
+++ b/lib/api/state/actions/font/font_string_actions.dart
@@ -95,6 +95,37 @@ class FontStringAddAction extends ReduxAction<AppState> {
   }
 }
 
+class FontStringEditAction extends ReduxAction<AppState> {
+  final FontStringDTO dto;
+
+  FontStringEditAction(this.dto);
+
+  @override
+  Future<AppState?> reduce() async {
+    if (state.selectedFont == null) return null;
+    final selected = state.selectedFont!;
+
+    final savedModel = await ApiService().fontApi.updateFontEntry(
+      selected.id!,
+      dto,
+    );
+
+    final updatedItems = state.selectedFont!.chars.items.map((char) {
+      return char.id == savedModel.id ? savedModel : char;
+    }).toList();
+
+    final newSelectedFont = selected.copyWith(
+      chars: selected.chars.copyWith(items: updatedItems),
+    );
+
+    final allFonts = state.fonts.items.map((font) {
+      return font.id == newSelectedFont.id ? newSelectedFont : font;
+    }).toList();
+
+    return _updateFontInState(state, allFonts, newSelectedFont);
+  }
+}
+
 
 class FontStringUpdateAction extends ReduxAction<AppState> {
   final FontStringDTO dto;

--- a/lib/feature/font/chars/char_list_view.dart
+++ b/lib/feature/font/chars/char_list_view.dart
@@ -39,7 +39,7 @@ class _CharListViewState extends State<CharListView>
             return CharListItem(
               key: ValueKey(key.id),
               fontString: key,
-              onEdit: () => _handleEdit(index, key.line),
+              onEdit: () => _handleEdit(key),
               onDelete: () =>
                   _handleDelete(widget.fontModel.selected.id!, key),
             );
@@ -67,23 +67,18 @@ class _CharListViewState extends State<CharListView>
   /// The method handles the edition of an existing char from the given [FontModel].
   /// For the edition, it opens a dialog with the current char value and allows the user to update it.
   /// If the user updates the char, the method updates the [FontModel] with the new value.
-  void _handleEdit(int index, String originalData) {
+  void _handleEdit(FontStringDTO dto) {
     showDialog(
       context: context,
       builder: (context) {
         return EntryUpdateDialog(
           title: 'Edit char',
           formKey: GlobalKey<FormState>(),
-          data: originalData,
+          data: dto.line,
           valueUpdate: (value) {
-            /*final String updatedValue = value;
-            if (updatedValue.isEmpty || updatedValue == originalData) return;
-            final List<String> modelChars = List.of(widget.fontModel.chars, growable: true);
-            modelChars.removeAt(index);
-            modelChars.insert(index, updatedValue);
-            final FontModel updatedModel =
-                widget.fontModel.selected.copyWith(chars: modelChars);
-            context.dispatch(UpdateFontAction(updatedModel));*/
+            final String updatedValue = value;
+            if (updatedValue.isEmpty || updatedValue == dto.line) return;
+            context.dispatch(FontStringEditAction(dto.copyWith(line: updatedValue)));
             Navigator.of(context).pop(true);
           },
         );


### PR DESCRIPTION
## Proposed changes

At the moment, it isn’t possible to edit a font string entry because the necessary Redux action is missing. This pull request adds that action and enables editing such entries.
 
## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)