### PR TITLE
Improve theme switch animation

### DIFF
--- a/lib/feature/base/dialog/animated_dialog.dart
+++ b/lib/feature/base/dialog/animated_dialog.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+
+class AnimatedDialog extends StatelessWidget {
+  const AnimatedDialog({
+    required this.child,
+    super.key,
+  });
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return TweenAnimationBuilder<double>(
+      duration: const Duration(milliseconds: 400),
+      curve: Curves.easeOutQuart,
+      tween: Tween<double>(begin: 0, end: 1),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final double width =
+              constraints.maxWidth < 1000 ? constraints.maxWidth : 1000;
+          final double height =
+              constraints.maxHeight < 600 ? constraints.maxHeight : 600;
+          return Dialog(
+            clipBehavior: Clip.hardEdge,
+            child: ConstrainedBox(
+              constraints: BoxConstraints(
+                minWidth: width * 0.8,
+                minHeight: height * 0.8,
+                maxHeight: height,
+                maxWidth: width,
+              ),
+              child: child,
+            ),
+          );
+        },
+      ),
+      builder: (context, value, child) {
+        return Opacity(
+          opacity: value,
+          child: Transform.scale(
+            scale: 0.5 + (value * 0.5),
+            child: child,
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/feature/settings/settings_base_row.dart
+++ b/lib/feature/settings/settings_base_row.dart
@@ -24,9 +24,7 @@ class SettingsBaseRow extends StatelessWidget {
     final theme = Theme.of(context);
     return Semantics(
       label: semanticsLabel ?? title,
-      child: AnimatedContainer(
-        duration: const Duration(milliseconds: 200),
-        curve: Curves.easeInOut,
+      child: Container(
         padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(8),

--- a/lib/feature/settings/settings_dialog.dart
+++ b/lib/feature/settings/settings_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:stelaris/feature/base/dialog/animated_dialog.dart';
 import 'package:stelaris/feature/settings/rows/accessibility_settings_row.dart';
 import 'package:stelaris/feature/settings/rows/misc_settings_row.dart';
 import 'package:stelaris/feature/settings/rows/theme_settings_row.dart';
@@ -11,66 +12,35 @@ class SettingsDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return TweenAnimationBuilder<double>(
-      duration: const Duration(milliseconds: 400),
-      curve: Curves.easeOutQuart,
-      tween: Tween<double>(begin: 0, end: 1),
-      child: LayoutBuilder(
-        builder: (context, constraints) {
-          final double width =
-              constraints.maxWidth < 1000 ? constraints.maxWidth : 1000;
-          final double height =
-              constraints.maxHeight < 600 ? constraints.maxHeight : 600;
-          return Dialog(
-            clipBehavior: Clip.hardEdge,
-            child: ConstrainedBox(
-              constraints: BoxConstraints(
-                minWidth: width * 0.8,
-                minHeight: height * 0.8,
-                maxHeight: height,
-                maxWidth: width,
-              ),
-              child: const Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  SettingsHeaderTile(),
-                  verticalSpacing25,
-                  Flexible(
-                    child: SingleChildScrollView(
-                      child: Padding(
-                        padding: EdgeInsets.symmetric(horizontal: 24),
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            heightTen,
-                            ThemeSettingsRow(),
-                            verticalSpacing25,
-                            AccessibilitySettingsRow(),
-                            verticalSpacing25,
-                            MiscSettingsRow(),
-                            verticalSpacing25,
-                            SettingsEndTile(),
-                            heightTen
-                          ],
-                        ),
-                      ),
-                    ),
-                  ),
-                ],
+    return const AnimatedDialog(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          SettingsHeaderTile(),
+          verticalSpacing25,
+          Flexible(
+            child: SingleChildScrollView(
+              child: Padding(
+                padding: EdgeInsets.symmetric(horizontal: 24),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    heightTen,
+                    ThemeSettingsRow(),
+                    verticalSpacing25,
+                    AccessibilitySettingsRow(),
+                    verticalSpacing25,
+                    MiscSettingsRow(),
+                    verticalSpacing25,
+                    SettingsEndTile(),
+                    heightTen
+                  ],
+                ),
               ),
             ),
-          );
-        },
-      ),
-      builder: (context, value, child) {
-        return Opacity(
-          opacity: value,
-          child: Transform.scale(
-            scale: 0.5 + (value * 0.5),
-            child: child,
           ),
-        );
-      },
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
## Proposed changes

Some widgets currently have a different delay during the theme switch. Most of these widgets are part of the settings dialog, which is affected by this issue. This pull request improves the widget structure to eliminate the delay.

The updated animation looks like this:

https://github.com/user-attachments/assets/ab75f074-0c3e-4ccc-bdc6-0be3178d8bb2

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)