### PR TITLE
rework: environment structure for more flexible value handling

### DIFF
--- a/lib/api/api_service.dart
+++ b/lib/api/api_service.dart
@@ -47,7 +47,7 @@ class ApiService {
   );
 
   /// Creates an instance of [ApiClient] with the backend URL.
-  ApiClient _createApiClient() => ApiClient(Environment.backendURl);
+  ApiClient _createApiClient() => ApiClient(Environment.backendUrl);
 
   /// Creates an instance of [ApiClient] with the generator URL.
   ApiClient _createGeneratorClient() => ApiClient(Environment.generatorUrl);

--- a/lib/env/environment.dart
+++ b/lib/env/environment.dart
@@ -1,6 +1,59 @@
-/// This file contains the environment variables for the app
-/// The pipeline should replace this constant with the right data
+/// Centralized environment configuration for build-time variables.
+///
+/// This class provides access to configuration values that are injected
+/// at build time via `--dart-define`. It is primarily intended for
+/// Flutter Web, where runtime environment variables are not available.
+///
+/// The configuration follows a *fail-fast* approach:
+/// required variables are validated on access and will cause the
+/// application to abort early if they are missing or empty.
+///
+/// Usage:
+///   flutter build web \
+///     --dart-define=CONCEPT_URL=https://example.com/docs \
+///     --dart-define=GIT_URL=https://github.com/example/repo
+///
+/// Notes:
+/// - All values are embedded at compile time and are therefore public.
+/// - This mechanism must not be used for secrets or private credentials.
+/// - Validation is performed via assertions to ensure early failure
+///   during development and CI builds.
+/// Do NOT store secrets here. All values are public.
 class Environment {
-  static const String backendURl = '';
-  static const String generatorUrl = '';
+  static const String _backendUrl = String.fromEnvironment('BACKEND_URL');
+
+  static const String _generatorUrl = String.fromEnvironment('GENERATOR_URL');
+
+  static const String _conceptUrl = String.fromEnvironment('CONCEPT_URL');
+
+  static const String _gitBugUrl = String.fromEnvironment('GIT_BUG_URL');
+
+  static const String _gitSuggestionUrl = String.fromEnvironment('GITHUB_SUGGESTION_URL');
+
+  /// Base URL of the backend API
+  static String get backendUrl => _require(_backendUrl, 'BACKEND_URL');
+
+  /// URL of the generator / worker service
+  static String get generatorUrl => _require(_generatorUrl, 'GENERATOR_URL');
+
+  /// Documentation / concept page URL
+  static String get conceptUrl => _require(_conceptUrl, 'CONCEPT_URL');
+
+  /// Issue tracker or repository URL
+  static String get gitBugUrl => _require(_gitBugUrl, 'GIT_BUG_URL');
+
+  /// Suggestion URL
+  static String get gitSuggestionUrl => _require(_gitSuggestionUrl, 'GITHUB_SUGGESTION_URL');
+
+  /// Ensures that a required build-time variable is present.
+  ///
+  /// [value] The resolved environment value.
+  /// [name]  The name of the dart-define variable (for error reporting).
+  ///
+  /// An assertion error is raised if the value is empty, causing the
+  /// application to fail early and visibly.
+  static String _require(String value, String name) {
+    assert(value.isNotEmpty, 'Missing required dart-define: $name');
+    return value;
+  }
 }

--- a/lib/env/environment.dart
+++ b/lib/env/environment.dart
@@ -1,3 +1,5 @@
+import 'package:stelaris/env/environment_validator.dart';
+
 /// Centralized environment configuration for build-time variables.
 ///
 /// This class provides access to configuration values that are injected
@@ -28,32 +30,27 @@ class Environment {
 
   static const String _gitBugUrl = String.fromEnvironment('GIT_BUG_URL');
 
-  static const String _gitSuggestionUrl = String.fromEnvironment('GITHUB_SUGGESTION_URL');
+  static const String _gitSuggestionUrl = String.fromEnvironment(
+    'GITHUB_SUGGESTION_URL',
+  );
 
   /// Base URL of the backend API
-  static String get backendUrl => _require(_backendUrl, 'BACKEND_URL');
+  static String get backendUrl =>
+      EnvironmentValidator.require(_backendUrl, 'BACKEND_URL');
 
   /// URL of the generator / worker service
-  static String get generatorUrl => _require(_generatorUrl, 'GENERATOR_URL');
+  static String get generatorUrl =>
+      EnvironmentValidator.require(_generatorUrl, 'GENERATOR_URL');
 
   /// Documentation / concept page URL
-  static String get conceptUrl => _require(_conceptUrl, 'CONCEPT_URL');
+  static String get conceptUrl =>
+      EnvironmentValidator.require(_conceptUrl, 'CONCEPT_URL');
 
   /// Issue tracker or repository URL
-  static String get gitBugUrl => _require(_gitBugUrl, 'GIT_BUG_URL');
+  static String get gitBugUrl =>
+      EnvironmentValidator.require(_gitBugUrl, 'GIT_BUG_URL');
 
   /// Suggestion URL
-  static String get gitSuggestionUrl => _require(_gitSuggestionUrl, 'GITHUB_SUGGESTION_URL');
-
-  /// Ensures that a required build-time variable is present.
-  ///
-  /// [value] The resolved environment value.
-  /// [name]  The name of the dart-define variable (for error reporting).
-  ///
-  /// An assertion error is raised if the value is empty, causing the
-  /// application to fail early and visibly.
-  static String _require(String value, String name) {
-    assert(value.isNotEmpty, 'Missing required dart-define: $name');
-    return value;
-  }
+  static String get gitSuggestionUrl =>
+      EnvironmentValidator.require(_gitSuggestionUrl, 'GITHUB_SUGGESTION_URL');
 }

--- a/lib/env/environment_validator.dart
+++ b/lib/env/environment_validator.dart
@@ -1,0 +1,14 @@
+class EnvironmentValidator {
+
+  /// Ensures that a required build-time variable is present.
+  ///
+  /// [value] The resolved environment value.
+  /// [name]  The name of the dart-define variable (for error reporting).
+  ///
+  /// An assertion error is raised if the value is empty, causing the
+  /// application to fail early and visibly.
+  static String require(String value, String name) {
+    assert(value.isNotEmpty, 'Missing required dart-define: $name');
+    return value;
+  }
+}

--- a/lib/feature/settings/rows/accessibility_settings_row.dart
+++ b/lib/feature/settings/rows/accessibility_settings_row.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:stelaris/env/environment.dart';
 import 'package:stelaris/feature/settings/settings_base_row.dart';
 import 'package:stelaris/feature/settings/settings_item.dart';
 import 'package:stelaris/util/constants.dart';
@@ -16,7 +17,7 @@ class AccessibilitySettingsRow extends StatelessWidget {
         title: context.l10n.settings_accessibility_body,
         subtitle: context.l10n.settings_accessibility_header,
         trailing: OutlinedButton(
-          onPressed: () => UriLauncher.launchURL(conceptURL),
+          onPressed: () => UriLauncher.launchURL(Environment.conceptUrl),
           child: Text(context.l10n.settings_accessibility_button),
         ),
       ),

--- a/lib/feature/settings/rows/misc_settings_row.dart
+++ b/lib/feature/settings/rows/misc_settings_row.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:stelaris/env/environment.dart';
 import 'package:stelaris/feature/settings/settings_base_row.dart';
 import 'package:stelaris/feature/settings/settings_item.dart';
 import 'package:stelaris/util/constants.dart';
@@ -18,7 +19,7 @@ class MiscSettingsRow extends StatelessWidget {
             title: context.l10n.settings_misc_bug_header,
             subtitle: context.l10n.settings_misc_bug_body,
             trailing: OutlinedButton(
-              onPressed: () => UriLauncher.launchURL(gitUrl),
+              onPressed: () => UriLauncher.launchURL(Environment.gitBugUrl),
               child: Text(context.l10n.settings_misc_bug_button),
             ),
           ),
@@ -27,7 +28,7 @@ class MiscSettingsRow extends StatelessWidget {
             title: context.l10n.settings_misc_suggestion_header,
             subtitle: context.l10n.settings_misc_suggestion_body,
             trailing: OutlinedButton(
-              onPressed: () => UriLauncher.launchURL(gitUrl),
+              onPressed: () => UriLauncher.launchURL(Environment.gitSuggestionUrl),
               child: Text(context.l10n.settings_misc_suggestion_button),
             ),
           ),

--- a/lib/util/constants.dart
+++ b/lib/util/constants.dart
@@ -60,6 +60,3 @@ const EdgeInsets dialogPadding = EdgeInsets.all(20);
 const double sizeFifty = 50;
 
 const borderRadius12 = BorderRadius.all(Radius.circular(12));
-
-const String conceptURL = 'https://docs.onelitefeather.network/doc/stelaris-S1nldMzySr#h-43-build-page';
-const String gitUrl = 'https://github.com/OneLiteFeatherNET/stelaris/issues';

--- a/test/environment/environment_validator_test.dart
+++ b/test/environment/environment_validator_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stelaris/env/environment_validator.dart';
+
+void main() {
+  test('throws assertion if value is empty', () {
+    expect(
+          () => EnvironmentValidator.require('', 'BACKEND_URL'),
+      throwsA(isA<AssertionError>()),
+    );
+  });
+
+  test('does not throw if value is present', () {
+    expect(
+          () => EnvironmentValidator.require('http://localhost', 'BACKEND_URL'),
+      returnsNormally,
+    );
+  });
+}


### PR DESCRIPTION
## Proposed changes

At the moment, handling important environment values is clunky and lacks flexibility. While this is acceptable for internal testing, it is not a sustainable approach for the future of the project.

The goal of reworking the environment structure is to make it more flexible. This change comes with both pros and cons. In Flutter, there is no reliable way to securely store secrets at runtime, unlike in some other languages. This is not a flaw of the language itself, but a limitation we need to account for.

**As a result, the environment file is not intended to store sensitive data. If critical or secret values are required, an alternative solution must be used.**

The app now requires the following properties:

- `BACKEND_URL`
- `GENERATOR_URL`
- `GIT_BUG_URL`
- `GITHUB_SUGGESTION_URL`

> **Note:** In the current setup, the app will fail to launch if any of these properties are missing.

The new structure requires a small migration for local usage. Since these values are required at launch, they must be provided at compile time. The start script must be enhanced with:

```text
--dart-define=BACKEND_URL=http://localhost:8080
--dart-define=GENERATOR_URL=http://localhost:8090
--dart-define=GIT_BUG_URL=url
--dart-define=GITHUB_SUGGESTION_URL=url
```

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)