### PR TITLE
feat(docker): serve the web bundle from a scratch image without nginx

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# The image needs exactly two things: the server sources and the compiled web
+# bundle. Everything else - Dart sources, tests, git history, CI config - would
+# only slow the build down and end up in the build cache for no reason.
+*
+!tool/webserver
+!build/web
+
+# Nothing below webroot/ from the repository is used; the bundle replaces it.
+tool/webserver/webroot

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,15 @@
-# The image needs exactly two things: the server sources and the compiled web
-# bundle. Everything else - Dart sources, tests, git history, CI config - would
-# only slow the build down and end up in the build cache for no reason.
-*
-!tool/webserver
-!build/web
+# Deliberately a plain exclude list with no `!` re-includes: BuildKit and the
+# legacy builder do not agree on what `*` plus an exception means, and getting
+# that wrong drops build/web from the context, which fails the image build with
+# a confusing "not found" instead of an obvious error.
+.git
+.github
+.idea
+.vscode
+.dart_tool
+docs
+test
 
-# Nothing below webroot/ from the repository is used; the bundle replaces it.
+# The placeholder web root must never reach an image; the Docker build replaces
+# it with the real bundle from build/web.
 tool/webserver/webroot

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -29,3 +29,27 @@ jobs:
         run: flutter analyze || true
       - name: Run tests (Web)
         run: flutter test --platform chrome
+
+  # The static server that ships the app in the production image. It has no
+  # third-party dependencies, so this job is just the toolchain and the tests.
+  webserver:
+    if: github.repository_owner == 'OneLiteFeatherNET'
+    name: Test Container Web Server
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tool/webserver
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+      - name: Init Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: tool/webserver/go.mod
+          cache-dependency-path: tool/webserver/go.mod
+      - name: Check formatting
+        run: test -z "$(gofmt -l .)" || { gofmt -d .; exit 1; }
+      - name: Run analyzer
+        run: go vet ./...
+      - name: Run tests
+        run: go test -race ./...

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -87,6 +87,10 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v7
         with:
+          # Without this the action builds from the Git context, which only
+          # contains committed files - and build/web is a downloaded artifact
+          # that is gitignored, so the image build cannot see it at all.
+          context: .
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,6 +44,16 @@ jobs:
         with:
           name: build
           path: build
+      # The image build embeds build/web. Without this check a missing or
+      # differently shaped artifact only surfaces as a COPY failure deep inside
+      # the Docker build.
+      - name: Verify the web bundle
+        run: |
+          if [ ! -f build/web/index.html ]; then
+            echo "::error::build/web/index.html is missing - the Flutter web artifact did not land where the image build expects it"
+            find build -maxdepth 2 | head -20
+            exit 1
+          fi
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   flutter:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v7
         name: Checkout
@@ -26,71 +28,61 @@ jobs:
         run: flutter pub run build_runner build --delete-conflicting-outputs
       - name: Build Web
         run: flutter build web --release --wasm
-      - name: Upload build artifacts
+
+      # A tag publishes its own version; every other push publishes a
+      # prerelease version derived from the release-please manifest, so branch
+      # builds get unique image tags and can never overwrite a released one
+      # (docker/metadata-action does not emit the {{major}}/{{major}}.{{minor}}
+      # aliases for a prerelease).
+      - name: Resolve image version
+        id: version
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
+        run: |
+          if [ "$REF_TYPE" = "tag" ]; then
+            VERSION="${REF_NAME#v}"
+          else
+            BASE="$(jq -r '.["."]' .release-please-manifest.json)"
+            SLUG="$(printf '%s' "$REF_NAME" | tr -c '0-9A-Za-z-' '-' | sed 's/-\+/-/g; s/^-//; s/-$//')"
+            # No commit sha in here: the branch tag is meant to move with the
+            # branch, and the workflow adds an immutable sha-<short> tag anyway.
+            VERSION="${BASE}-${SLUG}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Publishing image version $VERSION"
+
+      # The image build needs the Dockerfile, the server sources and the web
+      # bundle in one place. Assembling them here keeps docker-publish.yml free
+      # of any Flutter knowledge - it only ever sees a finished context.
+      - name: Assemble the Docker build context
+        run: |
+          mkdir -p docker-context/build
+          cp Dockerfile docker-context/
+          cp -r tool docker-context/tool
+          # The placeholder web root is replaced by the real bundle anyway.
+          rm -rf docker-context/tool/webserver/webroot
+          cp -r build/web docker-context/build/web
+          test -f docker-context/build/web/index.html
+
+      - name: Upload the Docker build context
         uses: actions/upload-artifact@v7
         with:
-          name: build
-          path: build
+          name: docker-context
+          path: docker-context
+          if-no-files-found: error
 
+  # Pushes through Harbor's proxy, which caps request bodies at 100 MB, so the
+  # blobs go up in chunks via regctl instead of one monolithic PUT.
   docker:
-    runs-on: ubuntu-latest
-    needs:
-      - flutter
-    steps:
-      - uses: actions/checkout@v7
-        name: Checkout
-      - name: Download build artifacts
-        uses: actions/download-artifact@v8
-        with:
-          name: build
-          path: build
-      # The image build embeds build/web. Without this check a missing or
-      # differently shaped artifact only surfaces as a COPY failure deep inside
-      # the Docker build.
-      - name: Verify the web bundle
-        run: |
-          if [ ! -f build/web/index.html ]; then
-            echo "::error::build/web/index.html is missing - the Flutter web artifact did not land where the image build expects it"
-            find build -maxdepth 2 | head -20
-            exit 1
-          fi
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          # list of Docker images to use as base name for tags
-          images: |
-            ${{ secrets.HARBOR_REGISTRY }}/stelaris/stelaris-ui
-          # generate Docker tags based on the following events/attributes
-          tags: |
-            type=schedule
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=sha
-      - name: Log in to OneLiteFeather Harbor
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.HARBOR_USERNAME }}
-          password: ${{ secrets.HARBOR_PASSWORD }}
-          registry: ${{ secrets.HARBOR_REGISTRY }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Build and push
-        uses: docker/build-push-action@v7
-        with:
-          # Without this the action builds from the Git context, which only
-          # contains committed files - and build/web is a downloaded artifact
-          # that is gitignored, so the image build cannot see it at all.
-          context: .
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+    needs: flutter
+    permissions:
+      contents: read
+      id-token: write # keyless cosign signing
+    uses: OneLiteFeatherNET/workflows/.github/workflows/docker-publish.yml@v2.8.1
+    with:
+      image-name: "stelaris/stelaris-ui"
+      version: ${{ needs.flutter.outputs.version }}
+      context: "docker-context"
+      artifact-name: "docker-context"
+    secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# Compiled output of the container web server (tool/webserver)
+tool/webserver/webserver

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ LABEL maintainer="OneLiteFeatherNET <contact@onelitefeather.net>"
 LABEL org.opencontainers.image.title="Stelaris UI"
 LABEL org.opencontainers.image.description="Stelaris UI web application served from a scratch image by a static Go binary"
 LABEL org.opencontainers.image.vendor="OneLiteFeatherNET"
-LABEL org.opencontainers.image.source="https://github.com/OneLiteFeatherNET/stelaris-ui"
+LABEL org.opencontainers.image.source="https://github.com/OneLiteFeatherNET/stelaris"
 LABEL org.opencontainers.image.base.name="scratch"
 LABEL stage="production"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,76 @@
-FROM nginx:1.31.4-alpine
+# syntax=docker/dockerfile:1
+
+# Stelaris UI production image.
+#
+# The runtime stage is FROM scratch and contains exactly one file: a statically
+# linked binary with the compiled Flutter web bundle embedded in it. There is no
+# nginx, no shell, no libc, no package manager and no writable path, so the only
+# code that can run in this container is the server itself.
+#
+# The Flutter bundle is expected at build/web in the build context, produced by
+#   flutter build web --release --wasm
+# (the CI workflow builds it in a separate job and downloads it as an artifact).
+
+# Pinned to a full patch version on purpose: the Go standard library is the only
+# dependency this image has, so Renovate keeping this tag current is what keeps
+# the image free of known CVEs.
+FROM golang:1.26.7-alpine AS build
+
+# Version string reported by /stelaris-ui -version and the startup log.
+ARG VERSION=dev
+
+WORKDIR /src
+
+# No third-party modules: the server is standard library only, which is what
+# keeps the supply chain of this image down to Go itself.
+COPY tool/webserver/ ./
+
+# The checked-in webroot/ is only a placeholder for local development; the real
+# bundle replaces it wholesale so nothing from it can leak into the image.
+RUN rm -rf webroot && mkdir webroot
+COPY build/web/ ./webroot/
+
+# Precompress the text-ish parts of the bundle once, here, instead of burning
+# CPU on every request at runtime. Files below 1 KiB are skipped because gzip
+# framing usually makes them bigger. The server picks the .gz sibling up
+# automatically and falls back to the plain file for clients without gzip.
+RUN find webroot -type f \
+        \( -name '*.js' -o -name '*.mjs' -o -name '*.json' -o -name '*.html' \
+        -o -name '*.css' -o -name '*.svg' -o -name '*.xml' -o -name '*.txt' \
+        -o -name '*.map' -o -name 'NOTICES' \) \
+        -size +1k -exec gzip -9 -k -f {} +
+
+# CGO_ENABLED=0 is what makes the binary static and therefore runnable in an
+# image with no libc at all. -trimpath and -buildid= keep build paths and
+# non-deterministic ids out of the artifact.
+ENV CGO_ENABLED=0 GOFLAGS=-mod=readonly
+RUN go build -trimpath -ldflags="-s -w -buildid= -X main.version=${VERSION}" -o /out/stelaris-ui .
+
+# Fail the build rather than shipping an image that cannot serve the app.
+RUN go vet ./... && /out/stelaris-ui -version
+
+
+FROM scratch
+
 LABEL maintainer="OneLiteFeatherNET <contact@onelitefeather.net>"
+LABEL org.opencontainers.image.title="Stelaris UI"
+LABEL org.opencontainers.image.description="Stelaris UI web application served from a scratch image by a static Go binary"
+LABEL org.opencontainers.image.vendor="OneLiteFeatherNET"
+LABEL org.opencontainers.image.source="https://github.com/OneLiteFeatherNET/stelaris-ui"
+LABEL org.opencontainers.image.base.name="scratch"
 LABEL stage="production"
-WORKDIR /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
-COPY build/web ./
-EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]
-LABEL version="1.0"
-LABEL description="Stelaris UI web application"
+
+COPY --from=build /out/stelaris-ui /stelaris-ui
+
+# Numeric because scratch has no /etc/passwd to resolve a name against. 65532 is
+# the conventional "nonroot" uid, and the server binds an unprivileged port so
+# it never needs CAP_NET_BIND_SERVICE.
+USER 65532:65532
+
+EXPOSE 8080
+
+# No shell and no curl in the image, so the binary health-checks itself.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=2s --retries=3 \
+    CMD ["/stelaris-ui", "-healthcheck"]
+
+ENTRYPOINT ["/stelaris-ui"]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,21 @@ To run the application on your local computer, follow these steps:
   flutter run  
   ```  
   
+## Docker
+
+The production image is built `FROM scratch` and contains a single file: a
+static binary with the compiled web bundle embedded in it - no nginx, no shell,
+no package manager.
+
+```sh
+flutter build web --release --wasm
+docker build -t stelaris-ui:local .
+docker run --rm -p 8080:8080 stelaris-ui:local
+```
+
+See [docs/docker-image.md](docs/docker-image.md) for configuration, response
+headers and deployment notes.
+
 ## Wiki
 
 You can find the Wiki under the following [Link](https://gitlab.onelitefeather.dev/dungeon/frontend/stelaris-ui/-/wikis/pages)

--- a/README.md
+++ b/README.md
@@ -29,8 +29,15 @@ no package manager.
 ```sh
 flutter build web --release --wasm
 docker build -t stelaris-ui:local .
-docker run --rm -p 8080:8080 stelaris-ui:local
+docker run --rm -p 8080:8080 \
+  -e STELARIS_BACKEND_URL=http://localhost:8081 \
+  stelaris-ui:local
 ```
+
+The backend URLs are **not** compiled into the image - the server serves them as
+`/config.json` and the app reads them at startup, so one image runs against every
+environment. `lib/env/environment.dart` still provides the values for a local
+`flutter run`.
 
 See [docs/docker-image.md](docs/docker-image.md) for configuration, response
 headers and deployment notes.

--- a/docs/docker-image.md
+++ b/docs/docker-image.md
@@ -26,7 +26,7 @@ Measured against the image this replaces (`nginx:1.31.4-alpine`):
 | OS packages | 71 | 0 |
 | Files in the image | 2130 | 1 |
 | Executables in `bin`/`sbin` | 340 | 1 |
-| Image size (without the bundle) | 26.3 MB | 3.3 MB (bundle included) |
+| Image size, same 45 MB bundle | 42.0 MB | 19.9 MB (precompressed copies included) |
 | Shell available to an attacker | `/bin/sh` (busybox) | none |
 | Runs as | root, drops to `nginx` for workers | uid 65532, never root |
 | Listens on | port 80 (privileged) | port 8080 (unprivileged) |

--- a/docs/docker-image.md
+++ b/docs/docker-image.md
@@ -1,0 +1,193 @@
+# The Stelaris UI container image
+
+The production image is built `FROM scratch` and contains **one file**: a
+statically linked Go binary with the compiled Flutter web bundle embedded in it.
+
+```
+$ docker export $(docker create stelaris-ui) | tar -t
+stelaris-ui
+```
+
+No nginx, no shell, no libc, no package manager, no writable path. Nothing in
+the image can be executed except the server itself, which serves `GET` and
+`HEAD` for files that were baked in at build time and nothing else.
+
+## Why not nginx
+
+nginx is a reverse proxy, load balancer, TLS terminator, FastCGI/uwsgi gateway
+and scripting host that also happens to serve static files. Stelaris UI needs
+the last of those. Everything else is attack surface that has to be patched,
+scanned and reasoned about for the lifetime of the project.
+
+Measured against the image this replaces (`nginx:1.31.4-alpine`):
+
+| | nginx:1.31.4-alpine | scratch image |
+| --- | --- | --- |
+| OS packages | 71 | 0 |
+| Files in the image | 2130 | 1 |
+| Executables in `bin`/`sbin` | 340 | 1 |
+| Image size (without the bundle) | 26.3 MB | 3.3 MB (bundle included) |
+| Shell available to an attacker | `/bin/sh` (busybox) | none |
+| Runs as | root, drops to `nginx` for workers | uid 65532, never root |
+| Listens on | port 80 (privileged) | port 8080 (unprivileged) |
+
+Both images happened to report zero known CVEs at the time this was written -
+the point is not today's CVE count but how much software has to stay CVE-free.
+Here that is the Go standard library and ~400 lines of our own code.
+
+### Options that were considered
+
+| Option | Verdict |
+| --- | --- |
+| Keep nginx (alpine) | Works, but ships an entire proxy stack, a shell and 71 packages to serve static files. |
+| Distroless (`gcr.io/distroless/static:nonroot`) plus a static server | Nearly as small, but still ships `/etc/passwd`, CA bundles and tzdata we do not use, and adds a third-party base image to the supply chain. |
+| A third-party static server binary (`static-web-server`, `darkhttpd`, `thttpd`, Caddy) | Removes nginx but replaces it with another externally maintained network-facing binary, plus a config file the image has to read. |
+| No server at all - an image that only carries the bundle | The smallest possible attack surface, and the right answer *if* the bundle is mounted into something else (a CDN, an ingress that serves static content, an init container that copies into a shared volume). It cannot be deployed on its own, which is how Stelaris UI is deployed today. See "Serving the bundle without any server" below. |
+| **Static Go binary with the bundle embedded, on scratch** | **Chosen.** One file, zero third-party dependencies, no config file, no filesystem access at runtime. | 
+
+### Why a Dart binary is not an option
+
+Compiling the server in Dart would have kept the project single-language, but
+`dart compile exe` links against glibc and cannot run in an image with no libc.
+Go was picked because `CGO_ENABLED=0` produces a genuinely static binary and
+because its standard library covers everything needed here - the server has no
+third-party dependencies at all, so `go.mod` needs no `go.sum`.
+
+### Serving the bundle without any server
+
+If Stelaris UI ever moves behind something that serves static files itself
+(a CDN, an S3-style bucket, an ingress with a static backend), the server
+becomes unnecessary. The build stage already produces the bundle as plain files,
+so an "artifact only" image is a two-line change - the runtime piece of this
+setup is deliberately the part that is easy to delete.
+
+## Building
+
+The image expects a finished Flutter web build at `build/web` in the build
+context. CI builds it in a separate job and downloads it as an artifact; locally:
+
+```sh
+flutter build web --release --wasm
+docker build -t stelaris-ui:local .
+docker run --rm -p 8080:8080 stelaris-ui:local
+```
+
+The build fails loudly if `build/web` is missing rather than shipping an image
+that serves a placeholder page.
+
+## Configuration
+
+Everything is an environment variable - the container reads no files at runtime.
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `STELARIS_ADDR` | `:8080` | Listen address. Unprivileged port, so no capabilities are needed. |
+| `STELARIS_CSP` | see below | Full `Content-Security-Policy` value. Set it to an empty string to drop the header entirely. |
+| `STELARIS_CONNECT_SRC` | `'self' https:` | `connect-src` of the default policy. This is the one directive that depends on the deployment, because it has to allow the Stelaris backend. Ignored when `STELARIS_CSP` is set. |
+| `STELARIS_CROSS_ORIGIN_ISOLATION` | `false` | Sends COOP/COEP. See below. |
+| `STELARIS_COEP` | `credentialless` | `credentialless` or `require-corp`, used only when isolation is on. |
+| `STELARIS_ASSET_CACHE_CONTROL` | `no-cache` | `Cache-Control` for non-entry-point files. Entry points always revalidate. |
+| `STELARIS_ACCESS_LOG` | `true` | One JSON line per request on stdout. Query strings are never logged. |
+
+### Response headers
+
+Sent on every response:
+
+```
+X-Content-Type-Options: nosniff
+X-Frame-Options: DENY
+Referrer-Policy: no-referrer
+Cross-Origin-Resource-Policy: same-origin
+Permissions-Policy: accelerometer=(), autoplay=(), camera=(), ...
+Content-Security-Policy: <configurable>
+```
+
+The default CSP is the strictest policy a Flutter web bundle actually runs
+under, not the strictest one a browser accepts:
+
+- `'unsafe-inline'` for scripts, because `web/index.html` carries inline
+  bootstrap and theme-preload scripts and Flutter's loader does not support CSP
+  nonces ([flutter/flutter#167800](https://github.com/flutter/flutter/issues/167800)).
+- `'unsafe-eval'` and `'wasm-unsafe-eval'`, because CanvasKit and the Wasm
+  entrypoint compile code at runtime
+  ([flutter/flutter#127658](https://github.com/flutter/flutter/issues/127658)).
+  Building with `flutter build web --csp` would allow dropping `'unsafe-eval'`.
+- `blob:` for scripts and workers, because the engine spawns its web workers
+  from blob URLs.
+
+TLS and HSTS are intentionally not handled here: the container speaks plain HTTP
+and the ingress terminates TLS.
+
+### Cross-origin isolation (COOP/COEP)
+
+`flutter build web --wasm` renders multi-threaded only in a cross-origin
+isolated context, which requires `Cross-Origin-Opener-Policy: same-origin` and
+`Cross-Origin-Embedder-Policy: credentialless` (or `require-corp`). Without
+them the engine silently falls back to the single-threaded Skwasm build - it
+works, it is just slower.
+
+It is off by default for two reasons:
+
+1. Isolation breaks every cross-origin resource that does not opt in via CORP or
+   CORS, which includes anything the backend might serve.
+2. Multi-threaded Skwasm currently renders a blank page under Chrome 146 when
+   isolation is on ([flutter/flutter#184843](https://github.com/flutter/flutter/issues/184843),
+   open at the time of writing).
+
+Turn it on with `STELARIS_CROSS_ORIGIN_ISOLATION=true` once that is fixed and
+verified against the deployed backend.
+
+### Caching
+
+Flutter does not put content hashes in its output file names - `main.dart.wasm`
+keeps its name across builds - so a long `max-age` pins browsers to a build that
+no longer exists on the server. The default is therefore `no-cache`, meaning
+"cache it, but revalidate": every file carries a strong `ETag` derived from its
+content, so revalidation costs a 304 and no body.
+
+Entry points (`index.html`, `flutter.js`, `flutter_bootstrap.js`,
+`flutter_service_worker.js`, `manifest.json`, `version.json`) always revalidate,
+regardless of `STELARIS_ASSET_CACHE_CONTROL`.
+
+Text assets are gzipped once at image build time; the server picks the `.gz`
+sibling when the client accepts gzip and serves it under a separate `ETag`.
+Brotli would compress better but is not in the Go standard library, and a
+dependency is a worse trade than a few percent of bandwidth here.
+
+### Routing
+
+`go_router` owns every path that is not a file, so a request that does not match
+a bundle file falls back to `index.html` with a 200 - the same behaviour as
+nginx's `try_files $uri $uri/ /index.html`. A request that *looks* like a file
+(anything with an extension) returns an honest 404 instead, because answering it
+with HTML breaks streaming Wasm instantiation and hides broken builds.
+
+## Running it safely
+
+The image supports every container hardening knob out of the box:
+
+```yaml
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: [ALL]
+  seccompProfile:
+    type: RuntimeDefault
+```
+
+There is no writable path in the image, no temp directory the server needs and
+no capability it asks for. The uid can be overridden with `--user`; nothing in
+the image is owned by a particular user.
+
+Health checks:
+
+- Kubernetes: `GET /healthz` on the container port.
+- Docker: built in - the binary health-checks itself
+  (`HEALTHCHECK CMD ["/stelaris-ui", "-healthcheck"]`), because there is no
+  shell or curl in the image to do it.
+
+The server is PID 1 and handles `SIGTERM` itself, so `docker stop` and pod
+termination shut it down in milliseconds instead of waiting out the grace period.

--- a/docs/docker-image.md
+++ b/docs/docker-image.md
@@ -64,16 +64,36 @@ setup is deliberately the part that is easy to delete.
 ## Building
 
 The image expects a finished Flutter web build at `build/web` in the build
-context. CI builds it in a separate job and downloads it as an artifact; locally:
+context:
 
 ```sh
 flutter build web --release --wasm
 docker build -t stelaris-ui:local .
-docker run --rm -p 8080:8080 stelaris-ui:local
+docker run --rm -p 8080:8080 \
+  -e STELARIS_BACKEND_URL=http://localhost:8081 \
+  stelaris-ui:local
 ```
 
 The build fails loudly if `build/web` is missing rather than shipping an image
 that serves a placeholder page.
+
+### In CI
+
+The `flutter` job builds the bundle, assembles `Dockerfile` + `tool/webserver` +
+`build/web` into a `docker-context` artifact, and hands it to the org-wide
+[`docker-publish.yml`](https://github.com/OneLiteFeatherNET/workflows), which
+builds the image and pushes it with **chunked blob uploads** via `regctl`.
+
+That is not a preference: Harbor sits behind a proxy that caps request bodies at
+100 MB, and a plain `docker push` sends each layer as one request. The image's
+bundle layer is comfortably over that, so `docker push` fails - which is exactly
+what it did here, as a `401` on the blob `HEAD` request. `regctl` splits any
+blob above 50 MiB into several `PATCH` requests instead.
+
+Image tags: a `v*.*.*` tag publishes that version; every other push publishes
+`<manifest-version>-<branch-slug>` plus an immutable `sha-<short>` tag. Branch
+builds are prerelease versions, so they never take over the `1`/`1.0` aliases of
+a released image.
 
 ## Configuration
 
@@ -82,12 +102,49 @@ Everything is an environment variable - the container reads no files at runtime.
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `STELARIS_ADDR` | `:8080` | Listen address. Unprivileged port, so no capabilities are needed. |
+| `STELARIS_BACKEND_URL` | *(empty)* | Backend base URL handed to the app via `/config.json`. See "Runtime configuration". |
+| `STELARIS_GENERATOR_URL` | *(empty)* | Generator service base URL, same mechanism. |
 | `STELARIS_CSP` | see below | Full `Content-Security-Policy` value. Set it to an empty string to drop the header entirely. |
-| `STELARIS_CONNECT_SRC` | `'self' https:` | `connect-src` of the default policy. This is the one directive that depends on the deployment, because it has to allow the Stelaris backend. Ignored when `STELARIS_CSP` is set. |
+| `STELARIS_CONNECT_SRC` | derived from the two URLs above | `connect-src` of the default policy. Set it only when the app must reach an origin that is neither of those. Ignored when `STELARIS_CSP` is set. |
 | `STELARIS_CROSS_ORIGIN_ISOLATION` | `false` | Sends COOP/COEP. See below. |
 | `STELARIS_COEP` | `credentialless` | `credentialless` or `require-corp`, used only when isolation is on. |
 | `STELARIS_ASSET_CACHE_CONTROL` | `no-cache` | `Cache-Control` for non-entry-point files. Entry points always revalidate. |
 | `STELARIS_ACCESS_LOG` | `true` | One JSON line per request on stdout. Query strings are never logged. |
+
+### Runtime configuration
+
+The app needs a backend URL, and that URL differs per environment. Compiling it
+into the bundle would make the image environment-specific - it could not be
+built once and promoted from staging to production - so the server hands it over
+at runtime instead:
+
+```
+GET /config.json
+Cache-Control: no-store
+
+{"backendUrl":"https://api.stelaris.example/v1","generatorUrl":"https://gen.stelaris.example"}
+```
+
+`lib/env/runtime_config.dart` fetches this before the first API call
+(`RuntimeConfig.load()` in `main()`), and `ApiService` reads
+`RuntimeConfig.current`. The rules:
+
+- The endpoint always wins over a `config.json` that happens to be in the
+  bundle, so a stale file in a build cannot override a live deployment.
+- `no-store`, always. A cached configuration outlives the deployment that
+  produced it and then points the app at the wrong backend.
+- Any field the server leaves empty falls back to the value compiled into
+  `lib/env/environment.dart`, which is what a local `flutter run` uses. A
+  missing, unreachable or malformed `/config.json` is not fatal for the same
+  reason - the app starts on the compiled-in defaults and the failure shows up
+  in the console and in the first API call.
+- `connect-src` in the default CSP is derived from these same URLs, so the
+  policy cannot drift away from the configuration and quietly block the backend.
+
+The app requests `config.json` relative to the document base href. The image
+assumes a build with the default base href `/`; serving it under a sub path
+needs a build with a matching `--base-href` and an ingress that does not strip
+the prefix.
 
 ### Response headers
 

--- a/lib/api/api_service.dart
+++ b/lib/api/api_service.dart
@@ -6,7 +6,7 @@ import 'package:stelaris_models/stelaris_models.dart';
 import 'package:stelaris/api/service/font_api.dart';
 import 'package:stelaris/api/service/generate_api.dart';
 import 'package:stelaris/api/service/item_api.dart';
-import 'package:stelaris/env/environment.dart';
+import 'package:stelaris/env/runtime_config.dart';
 
 /// The [ApiService] class contains all web services which are used in the app to communicate with the backend.
 class ApiService {
@@ -45,8 +45,9 @@ class ApiService {
   );
 
   /// Creates an instance of [ApiClient] with the backend URL.
-  ApiClient _createApiClient() => ApiClient(Environment.backendURl);
+  ApiClient _createApiClient() => ApiClient(RuntimeConfig.current.backendUrl);
 
   /// Creates an instance of [ApiClient] with the generator URL.
-  ApiClient _createGeneratorClient() => ApiClient(Environment.generatorUrl);
+  ApiClient _createGeneratorClient() =>
+      ApiClient(RuntimeConfig.current.generatorUrl);
 }

--- a/lib/env/runtime_config.dart
+++ b/lib/env/runtime_config.dart
@@ -1,0 +1,109 @@
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+import 'package:stelaris/env/environment.dart';
+
+/// Settings the app reads when it starts instead of at build time.
+///
+/// The container image is built once and promoted from staging to production,
+/// so the backend it talks to must not be compiled into the bundle - an image
+/// that only works in one environment cannot be promoted between them. The web
+/// server renders [configFileName] from its own environment and the app adopts
+/// whatever it finds there.
+///
+/// [Environment] stays the source for a local `flutter run`, where nothing
+/// serves a configuration: its values are the fallback for every field the
+/// served configuration leaves empty.
+@immutable
+class RuntimeConfig {
+  const RuntimeConfig({required this.backendUrl, required this.generatorUrl});
+
+  /// The document the web server renders from its environment.
+  ///
+  /// Relative on purpose: it resolves against the base href, so a deployment
+  /// under a sub path keeps working.
+  static const String configFileName = 'config.json';
+
+  /// Values compiled into the bundle. Used unchanged when nothing is served.
+  static const RuntimeConfig compiledIn = RuntimeConfig(
+    backendUrl: Environment.backendURl,
+    generatorUrl: Environment.generatorUrl,
+  );
+
+  static RuntimeConfig _current = compiledIn;
+
+  /// The configuration in effect. Reads [compiledIn] until [load] has run.
+  static RuntimeConfig get current => _current;
+
+  /// Base URL of the Stelaris backend.
+  final String backendUrl;
+
+  /// Base URL of the code generator service.
+  final String generatorUrl;
+
+  /// Fetches [configFileName] and adopts what it provides.
+  ///
+  /// Never throws. A configuration that is missing, unreachable or malformed
+  /// leaves [compiledIn] in place: starting against the compiled-in defaults is
+  /// better than not starting at all, and the failure is visible in the console
+  /// and in the first failing API call.
+  ///
+  /// Pass [client] to drive this from a test without touching the network.
+  static Future<void> load({Dio? client}) async {
+    final Dio dio =
+        client ??
+        Dio(
+          BaseOptions(
+            connectTimeout: const Duration(seconds: 5),
+            receiveTimeout: const Duration(seconds: 5),
+          ),
+        );
+
+    try {
+      final Response<String> response = await dio.get<String>(
+        configFileName,
+        options: Options(responseType: ResponseType.plain),
+      );
+      final String? raw = response.data;
+      if (raw == null || raw.trim().isEmpty) {
+        return;
+      }
+      _current = _parse(raw);
+      // Anything at all: a malformed configuration must not keep the app from
+      // starting, and there is no error type worth distinguishing here.
+    } catch (error) {
+      debugPrint(
+        'Could not load $configFileName ($error); '
+        'falling back to the compiled-in configuration.',
+      );
+    }
+  }
+
+  /// Restores [compiledIn]. Tests share process state, so they need this.
+  @visibleForTesting
+  static void reset() => _current = compiledIn;
+
+  static RuntimeConfig _parse(String raw) {
+    final Object? decoded = jsonDecode(raw);
+    if (decoded is! Map<String, dynamic>) {
+      throw const FormatException('config.json must contain a JSON object');
+    }
+    return RuntimeConfig(
+      backendUrl: _valueOr(decoded['backendUrl'], compiledIn.backendUrl),
+      generatorUrl: _valueOr(decoded['generatorUrl'], compiledIn.generatorUrl),
+    );
+  }
+
+  /// An absent, non-string or blank value falls back, so a half-filled
+  /// configuration cannot silently point a client at an empty URL.
+  static String _valueOr(Object? value, String fallback) {
+    if (value is String) {
+      final String trimmed = value.trim();
+      if (trimmed.isNotEmpty) {
+        return trimmed;
+      }
+    }
+    return fallback;
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,10 +3,15 @@ import 'package:material_ui/material_ui.dart';
 import 'package:localstorage/localstorage.dart';
 import 'package:stelaris/api/state/app_presistor.dart';
 import 'package:stelaris/api/state/app_state.dart';
+import 'package:stelaris/env/runtime_config.dart';
 import 'package:stelaris/feature/home/home.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  // Before anything can talk to an API: the backend URLs come from the server
+  // that serves the bundle, not from the bundle itself.
+  await RuntimeConfig.load();
   await initLocalStorage();
   
   final persistor = AppPersistor();

--- a/test/env/runtime_config_test.dart
+++ b/test/env/runtime_config_test.dart
@@ -1,0 +1,136 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stelaris/env/runtime_config.dart';
+
+import '../support/fake_http_client_adapter.dart';
+
+/// A [Dio] whose every request is answered by [adapter], so nothing here
+/// touches the network.
+Dio _dioWith(HttpClientAdapter adapter) => Dio()..httpClientAdapter = adapter;
+
+/// Answers with [body] verbatim, which is how a served config.json arrives.
+Dio _dioServing(String body) => _dioWith(
+  FakeHttpClientAdapter(
+    (_) => ResponseBody.fromString(
+      body,
+      200,
+      headers: {
+        Headers.contentTypeHeader: [Headers.jsonContentType],
+      },
+    ),
+  ),
+);
+
+/// Fails every request, standing in for a config.json that is not served.
+class _FailingAdapter implements HttpClientAdapter {
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async => throw DioException.connectionError(
+    requestOptions: options,
+    reason: 'no config served',
+  );
+
+  @override
+  void close({bool force = false}) {}
+}
+
+void main() {
+  setUp(RuntimeConfig.reset);
+  tearDown(RuntimeConfig.reset);
+
+  group('RuntimeConfig.load', () {
+    test('adopts the URLs the server provides', () async {
+      await RuntimeConfig.load(
+        client: _dioServing(
+          jsonEncode({
+            'backendUrl': 'https://api.stelaris.example',
+            'generatorUrl': 'https://generator.stelaris.example',
+          }),
+        ),
+      );
+
+      expect(RuntimeConfig.current.backendUrl, 'https://api.stelaris.example');
+      expect(
+        RuntimeConfig.current.generatorUrl,
+        'https://generator.stelaris.example',
+      );
+    });
+
+    test('requests a path relative to the base href', () async {
+      late final String requestedPath;
+      await RuntimeConfig.load(
+        client: _dioWith(
+          FakeHttpClientAdapter((options) {
+            requestedPath = options.path;
+            return ResponseBody.fromString('{}', 200);
+          }),
+        ),
+      );
+
+      // A leading slash would break a deployment under a sub path.
+      expect(requestedPath, RuntimeConfig.configFileName);
+      expect(requestedPath, isNot(startsWith('/')));
+    });
+
+    test(
+      'keeps the compiled-in value for a field the server leaves blank',
+      () async {
+        await RuntimeConfig.load(
+          client: _dioServing(
+            jsonEncode({
+              'backendUrl': 'https://api.stelaris.example',
+              'generatorUrl': '   ',
+            }),
+          ),
+        );
+
+        expect(
+          RuntimeConfig.current.backendUrl,
+          'https://api.stelaris.example',
+        );
+        expect(
+          RuntimeConfig.current.generatorUrl,
+          RuntimeConfig.compiledIn.generatorUrl,
+        );
+      },
+    );
+
+    test('falls back when nothing is served', () async {
+      await RuntimeConfig.load(client: _dioWith(_FailingAdapter()));
+
+      expect(RuntimeConfig.current.backendUrl, RuntimeConfig.compiledIn.backendUrl);
+    });
+
+    test('falls back on a malformed body instead of throwing', () async {
+      await RuntimeConfig.load(client: _dioServing('not json at all'));
+
+      expect(RuntimeConfig.current.backendUrl, RuntimeConfig.compiledIn.backendUrl);
+    });
+
+    test('falls back when the body is JSON but not an object', () async {
+      await RuntimeConfig.load(client: _dioServing('["nope"]'));
+
+      expect(RuntimeConfig.current.backendUrl, RuntimeConfig.compiledIn.backendUrl);
+    });
+
+    test('falls back on an empty body', () async {
+      await RuntimeConfig.load(client: _dioServing('   '));
+
+      expect(RuntimeConfig.current.backendUrl, RuntimeConfig.compiledIn.backendUrl);
+    });
+
+    test('ignores a value of the wrong type', () async {
+      await RuntimeConfig.load(
+        client: _dioServing(jsonEncode({'backendUrl': 42})),
+      );
+
+      expect(RuntimeConfig.current.backendUrl, RuntimeConfig.compiledIn.backendUrl);
+    });
+  });
+}

--- a/tool/webserver/config.go
+++ b/tool/webserver/config.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Config is the full runtime surface of the server. Everything is read from the
+// environment once at startup so the container can stay immutable: there is no
+// config file to mount, and therefore no file the container needs to read.
+type Config struct {
+	// Addr is the listen address. The default port is above 1024 so the process
+	// can run as an unprivileged user without CAP_NET_BIND_SERVICE.
+	Addr string
+
+	// CSP is the Content-Security-Policy sent with every response. Empty means
+	// the header is omitted entirely.
+	CSP string
+
+	// CrossOriginIsolation enables COOP/COEP, which lets the Wasm renderer use
+	// SharedArrayBuffer and render on multiple threads. Off by default: it is a
+	// performance opt-in, and cross-origin isolation breaks any cross-origin
+	// resource that does not opt in via CORP/CORS.
+	CrossOriginIsolation bool
+
+	// COEP is the Cross-Origin-Embedder-Policy value used when
+	// CrossOriginIsolation is on. "credentialless" is the friendlier of the two
+	// valid values because cross-origin resources do not have to send CORP.
+	COEP string
+
+	// AssetCacheControl is the Cache-Control value for bundle files that are not
+	// entry points. Flutter does not put content hashes in its output file names
+	// (main.dart.wasm keeps its name across builds), so the default revalidates
+	// instead of pinning clients to a build that no longer exists on the server.
+	AssetCacheControl string
+
+	// AccessLog toggles the one-line-per-request JSON log on stdout.
+	AccessLog bool
+}
+
+// defaultCSP is deliberately not the strictest policy that a browser accepts,
+// but the strictest one a Flutter web bundle actually runs under:
+//   - 'unsafe-inline' for scripts: web/index.html carries inline bootstrap and
+//     theme-preload scripts, and Flutter's loader does not support CSP nonces
+//     (flutter/flutter#167800).
+//   - 'unsafe-eval' and 'wasm-unsafe-eval': CanvasKit and the Wasm entrypoint
+//     compile code at runtime (flutter/flutter#127658). A build produced with
+//     `flutter build web --csp` can drop 'unsafe-eval'.
+//   - blob: for scripts and workers: the engine spawns its web workers from
+//     blob URLs.
+//
+// %s is the connect-src value, which is the one directive that depends on the
+// deployment (it has to allow the Stelaris backend).
+const defaultCSP = "default-src 'self'; " +
+	"base-uri 'self'; " +
+	"object-src 'none'; " +
+	"frame-ancestors 'none'; " +
+	"form-action 'none'; " +
+	"script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' blob:; " +
+	"style-src 'self' 'unsafe-inline'; " +
+	"img-src 'self' data: blob:; " +
+	"font-src 'self' data:; " +
+	"media-src 'self' data: blob:; " +
+	"worker-src 'self' blob:; " +
+	"manifest-src 'self'; " +
+	"connect-src %s"
+
+// LoadConfig builds a Config from environment variables. lookup is normally
+// os.LookupEnv; tests pass their own.
+func LoadConfig(lookup func(string) (string, bool)) Config {
+	cfg := Config{
+		Addr:                 envString(lookup, "STELARIS_ADDR", ":8080"),
+		CrossOriginIsolation: envBool(lookup, "STELARIS_CROSS_ORIGIN_ISOLATION", false),
+		COEP:                 envString(lookup, "STELARIS_COEP", "credentialless"),
+		AssetCacheControl:    envString(lookup, "STELARIS_ASSET_CACHE_CONTROL", "no-cache"),
+		AccessLog:            envBool(lookup, "STELARIS_ACCESS_LOG", true),
+	}
+
+	// An explicitly set STELARIS_CSP always wins, including an empty value,
+	// which is how an operator turns the header off.
+	if csp, ok := lookup("STELARIS_CSP"); ok {
+		cfg.CSP = strings.TrimSpace(csp)
+	} else {
+		connectSrc := envString(lookup, "STELARIS_CONNECT_SRC", "'self' https:")
+		cfg.CSP = strings.Replace(defaultCSP, "%s", connectSrc, 1)
+	}
+
+	if cfg.COEP != "require-corp" {
+		cfg.COEP = "credentialless"
+	}
+
+	return cfg
+}
+
+func envString(lookup func(string) (string, bool), key, fallback string) string {
+	if v, ok := lookup(key); ok {
+		if trimmed := strings.TrimSpace(v); trimmed != "" {
+			return trimmed
+		}
+	}
+	return fallback
+}
+
+func envBool(lookup func(string) (string, bool), key string, fallback bool) bool {
+	v, ok := lookup(key)
+	if !ok {
+		return fallback
+	}
+	parsed, err := strconv.ParseBool(strings.TrimSpace(v))
+	if err != nil {
+		return fallback
+	}
+	return parsed
+}
+
+// osLookupEnv is the production lookup function.
+func osLookupEnv(key string) (string, bool) { return os.LookupEnv(key) }

--- a/tool/webserver/config.go
+++ b/tool/webserver/config.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -37,6 +38,13 @@ type Config struct {
 
 	// AccessLog toggles the one-line-per-request JSON log on stdout.
 	AccessLog bool
+
+	// BackendURL and GeneratorURL are handed to the app at runtime via
+	// /config.json. They are deliberately not baked into the bundle: the same
+	// image has to run against dev, staging and production, and an image that
+	// only works in one environment cannot be promoted between them.
+	BackendURL   string
+	GeneratorURL string
 }
 
 // defaultCSP is deliberately not the strictest policy that a browser accepts,
@@ -75,6 +83,8 @@ func LoadConfig(lookup func(string) (string, bool)) Config {
 		COEP:                 envString(lookup, "STELARIS_COEP", "credentialless"),
 		AssetCacheControl:    envString(lookup, "STELARIS_ASSET_CACHE_CONTROL", "no-cache"),
 		AccessLog:            envBool(lookup, "STELARIS_ACCESS_LOG", true),
+		BackendURL:           envString(lookup, "STELARIS_BACKEND_URL", ""),
+		GeneratorURL:         envString(lookup, "STELARIS_GENERATOR_URL", ""),
 	}
 
 	// An explicitly set STELARIS_CSP always wins, including an empty value,
@@ -82,7 +92,7 @@ func LoadConfig(lookup func(string) (string, bool)) Config {
 	if csp, ok := lookup("STELARIS_CSP"); ok {
 		cfg.CSP = strings.TrimSpace(csp)
 	} else {
-		connectSrc := envString(lookup, "STELARIS_CONNECT_SRC", "'self' https:")
+		connectSrc := envString(lookup, "STELARIS_CONNECT_SRC", connectSrcFor(cfg.BackendURL, cfg.GeneratorURL))
 		cfg.CSP = strings.Replace(defaultCSP, "%s", connectSrc, 1)
 	}
 
@@ -91,6 +101,48 @@ func LoadConfig(lookup func(string) (string, bool)) Config {
 	}
 
 	return cfg
+}
+
+// connectSrcFor derives the CSP connect-src from the backend URLs the app is
+// configured with, so the policy and the configuration cannot drift apart -
+// pointing the app at a backend it is not allowed to call is otherwise a very
+// quiet failure. Falls back to "'self' https:" when no backend is configured,
+// which keeps a bare `docker run` usable.
+func connectSrcFor(urls ...string) string {
+	origins := make([]string, 0, len(urls)+1)
+	seen := map[string]bool{}
+	for _, raw := range urls {
+		origin := originOf(raw)
+		if origin == "" || seen[origin] {
+			continue
+		}
+		seen[origin] = true
+		origins = append(origins, origin)
+	}
+	if len(origins) == 0 {
+		return "'self' https:"
+	}
+	return "'self' " + strings.Join(origins, " ")
+}
+
+// originOf reduces a URL to the scheme://host[:port] form CSP matches on,
+// dropping any path. Anything unparseable yields "" and is left out rather than
+// injected into the header verbatim.
+func originOf(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	switch u.Scheme {
+	case "http", "https":
+	default:
+		return ""
+	}
+	return u.Scheme + "://" + u.Host
 }
 
 func envString(lookup func(string) (string, bool), key, fallback string) string {

--- a/tool/webserver/config_test.go
+++ b/tool/webserver/config_test.go
@@ -45,6 +45,51 @@ func TestConnectSrcOverride(t *testing.T) {
 	}
 }
 
+// The policy is derived from the configured backends so the two cannot drift
+// apart - a backend the app may not call is a very quiet failure.
+func TestConnectSrcFollowsConfiguredBackends(t *testing.T) {
+	cfg := LoadConfig(lookupFrom(map[string]string{
+		"STELARIS_BACKEND_URL":   "https://api.stelaris.example/v1",
+		"STELARIS_GENERATOR_URL": "https://generator.stelaris.example",
+	}))
+
+	// The path is dropped: CSP matches origins.
+	want := "connect-src 'self' https://api.stelaris.example https://generator.stelaris.example"
+	if !strings.Contains(cfg.CSP, want) {
+		t.Errorf("CSP = %s, want it to contain %q", cfg.CSP, want)
+	}
+}
+
+func TestConnectSrcDeduplicatesAndIgnoresJunk(t *testing.T) {
+	cfg := LoadConfig(lookupFrom(map[string]string{
+		"STELARIS_BACKEND_URL":   "https://api.stelaris.example/a",
+		"STELARIS_GENERATOR_URL": "https://api.stelaris.example/b",
+	}))
+	if strings.Count(cfg.CSP, "https://api.stelaris.example") != 1 {
+		t.Errorf("origin repeated: %s", cfg.CSP)
+	}
+
+	// A value that is not an http(s) URL must not be injected into the header.
+	cfg = LoadConfig(lookupFrom(map[string]string{"STELARIS_BACKEND_URL": "javascript:alert(1)"}))
+	if strings.Contains(cfg.CSP, "javascript:") {
+		t.Errorf("junk leaked into the policy: %s", cfg.CSP)
+	}
+	if !strings.Contains(cfg.CSP, "connect-src 'self' https:") {
+		t.Errorf("expected the fallback connect-src, got: %s", cfg.CSP)
+	}
+}
+
+func TestExplicitConnectSrcOverridesDerivedOne(t *testing.T) {
+	cfg := LoadConfig(lookupFrom(map[string]string{
+		"STELARIS_BACKEND_URL": "https://api.stelaris.example",
+		"STELARIS_CONNECT_SRC": "'self' https://proxy.example",
+	}))
+
+	if !strings.Contains(cfg.CSP, "connect-src 'self' https://proxy.example") {
+		t.Errorf("explicit connect-src ignored: %s", cfg.CSP)
+	}
+}
+
 func TestExplicitCSPWins(t *testing.T) {
 	cfg := LoadConfig(lookupFrom(map[string]string{
 		"STELARIS_CSP":         "default-src 'none'",

--- a/tool/webserver/config_test.go
+++ b/tool/webserver/config_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func lookupFrom(env map[string]string) func(string) (string, bool) {
+	return func(key string) (string, bool) {
+		v, ok := env[key]
+		return v, ok
+	}
+}
+
+func TestConfigDefaults(t *testing.T) {
+	cfg := LoadConfig(lookupFrom(nil))
+
+	if cfg.Addr != ":8080" {
+		t.Errorf("Addr = %q, want :8080 (unprivileged port)", cfg.Addr)
+	}
+	if cfg.CrossOriginIsolation {
+		t.Error("cross-origin isolation must be opt-in")
+	}
+	if cfg.AssetCacheControl != "no-cache" {
+		t.Errorf("AssetCacheControl = %q, want no-cache", cfg.AssetCacheControl)
+	}
+	if !cfg.AccessLog {
+		t.Error("access log should default to on")
+	}
+	if !strings.Contains(cfg.CSP, "connect-src 'self' https:") {
+		t.Errorf("default CSP connect-src is wrong: %s", cfg.CSP)
+	}
+}
+
+func TestConnectSrcOverride(t *testing.T) {
+	cfg := LoadConfig(lookupFrom(map[string]string{
+		"STELARIS_CONNECT_SRC": "'self' https://api.stelaris.example",
+	}))
+
+	if !strings.Contains(cfg.CSP, "connect-src 'self' https://api.stelaris.example") {
+		t.Errorf("connect-src not applied: %s", cfg.CSP)
+	}
+	if strings.Contains(cfg.CSP, "%s") {
+		t.Errorf("CSP placeholder left in output: %s", cfg.CSP)
+	}
+}
+
+func TestExplicitCSPWins(t *testing.T) {
+	cfg := LoadConfig(lookupFrom(map[string]string{
+		"STELARIS_CSP":         "default-src 'none'",
+		"STELARIS_CONNECT_SRC": "'self'",
+	}))
+
+	if cfg.CSP != "default-src 'none'" {
+		t.Errorf("CSP = %q", cfg.CSP)
+	}
+}
+
+// An empty STELARIS_CSP is how an operator turns the header off, which has to be
+// distinguishable from "not set".
+func TestEmptyCSPDisablesHeader(t *testing.T) {
+	cfg := LoadConfig(lookupFrom(map[string]string{"STELARIS_CSP": ""}))
+
+	if cfg.CSP != "" {
+		t.Errorf("CSP = %q, want empty", cfg.CSP)
+	}
+}
+
+func TestCOEPFallsBackToCredentialless(t *testing.T) {
+	if got := LoadConfig(lookupFrom(map[string]string{"STELARIS_COEP": "require-corp"})).COEP; got != "require-corp" {
+		t.Errorf("COEP = %q", got)
+	}
+	if got := LoadConfig(lookupFrom(map[string]string{"STELARIS_COEP": "nonsense"})).COEP; got != "credentialless" {
+		t.Errorf("COEP = %q, want credentialless for an invalid value", got)
+	}
+}
+
+func TestBoolParsing(t *testing.T) {
+	cases := map[string]bool{"true": true, "1": true, "false": false, "0": false}
+	for value, want := range cases {
+		cfg := LoadConfig(lookupFrom(map[string]string{"STELARIS_CROSS_ORIGIN_ISOLATION": value}))
+		if cfg.CrossOriginIsolation != want {
+			t.Errorf("%q -> %v, want %v", value, cfg.CrossOriginIsolation, want)
+		}
+	}
+	// Garbage must not silently flip a security-relevant setting.
+	if LoadConfig(lookupFrom(map[string]string{"STELARIS_ACCESS_LOG": "maybe"})).AccessLog != true {
+		t.Error("invalid bool should fall back to the default")
+	}
+}
+
+func TestHealthURL(t *testing.T) {
+	cases := map[string]string{
+		":8080":          "http://127.0.0.1:8080/healthz",
+		"0.0.0.0:8080":   "http://127.0.0.1:8080/healthz",
+		"127.0.0.1:9000": "http://127.0.0.1:9000/healthz",
+		"[::]:8080":      "http://127.0.0.1:8080/healthz",
+		"[::1]:8080":     "http://[::1]:8080/healthz",
+	}
+	for addr, want := range cases {
+		got, err := healthURL(addr)
+		if err != nil {
+			t.Errorf("%s: %v", addr, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("%s -> %s, want %s", addr, got, want)
+		}
+	}
+
+	if _, err := healthURL("not-an-address"); err == nil {
+		t.Error("expected an error for a malformed listen address")
+	}
+}

--- a/tool/webserver/go.mod
+++ b/tool/webserver/go.mod
@@ -1,3 +1,3 @@
-module github.com/OneLiteFeatherNET/stelaris-ui/tool/webserver
+module github.com/OneLiteFeatherNET/stelaris/tool/webserver
 
 go 1.26

--- a/tool/webserver/go.mod
+++ b/tool/webserver/go.mod
@@ -1,0 +1,3 @@
+module github.com/OneLiteFeatherNET/stelaris-ui/tool/webserver
+
+go 1.26

--- a/tool/webserver/main.go
+++ b/tool/webserver/main.go
@@ -1,0 +1,179 @@
+// Command webserver serves the compiled Stelaris UI web bundle.
+//
+// It exists so the production image can be built FROM scratch: the bundle is
+// embedded into this binary, which is the only file in the image. There is no
+// shell, no package manager, no libc and no configuration file to read, so the
+// image has no attack surface beyond this program and the Go runtime.
+//
+// It is intentionally not a web server in the nginx sense. It answers GET and
+// HEAD for files that were baked in at build time, and nothing else.
+package main
+
+import (
+	"context"
+	"embed"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+// bundleFS holds the Flutter web build. The checked-in webroot/ is a placeholder
+// so the package builds and tests without a Flutter toolchain; the Docker build
+// replaces it with the real build/web output before compiling.
+//
+//go:embed all:webroot
+var bundleFS embed.FS
+
+// version is stamped by the Docker build via -ldflags.
+var version = "dev"
+
+const (
+	// Slowloris protection: a client that cannot send its request headers in
+	// ten seconds is not a browser loading a UI.
+	readHeaderTimeout = 10 * time.Second
+	readTimeout       = 15 * time.Second
+	// Generous, because the Wasm bundle is multiple megabytes and mobile
+	// connections are slow.
+	writeTimeout = 120 * time.Second
+	idleTimeout  = 60 * time.Second
+	// The default of 1 MiB is pointless for a static bundle.
+	maxHeaderBytes = 16 << 10
+
+	shutdownGrace = 10 * time.Second
+)
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+}
+
+func run(args []string) error {
+	cfg := LoadConfig(osLookupEnv)
+
+	// The scratch image has no shell and no curl, so the binary doubles as its
+	// own health check client: HEALTHCHECK CMD ["/stelaris-ui", "-healthcheck"].
+	for _, arg := range args {
+		switch arg {
+		case "-healthcheck", "--healthcheck":
+			return healthcheck(cfg.Addr)
+		case "-version", "--version":
+			fmt.Println(version)
+			return nil
+		default:
+			return fmt.Errorf("unknown argument %q", arg)
+		}
+	}
+
+	log := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	webroot, err := fs.Sub(bundleFS, "webroot")
+	if err != nil {
+		return fmt.Errorf("open embedded bundle: %w", err)
+	}
+
+	srv, err := NewServer(webroot, cfg, log)
+	if err != nil {
+		return fmt.Errorf("index bundle: %w", err)
+	}
+
+	httpServer := &http.Server{
+		Addr:              cfg.Addr,
+		Handler:           srv,
+		ReadHeaderTimeout: readHeaderTimeout,
+		ReadTimeout:       readTimeout,
+		WriteTimeout:      writeTimeout,
+		IdleTimeout:       idleTimeout,
+		MaxHeaderBytes:    maxHeaderBytes,
+		ErrorLog:          slog.NewLogLogger(log.Handler(), slog.LevelWarn),
+	}
+
+	listener, err := net.Listen("tcp", cfg.Addr)
+	if err != nil {
+		return fmt.Errorf("listen on %s: %w", cfg.Addr, err)
+	}
+
+	log.Info("stelaris-ui starting",
+		slog.String("version", version),
+		slog.String("addr", listener.Addr().String()),
+		slog.Int("files", len(srv.assets)),
+		slog.Bool("cross_origin_isolation", cfg.CrossOriginIsolation),
+		slog.Bool("csp", cfg.CSP != ""),
+	)
+	log.Debug("bundle contents", slog.Any("files", srv.bundleFiles()))
+
+	// This process is PID 1 in the container. Nothing else reaps signals for
+	// it, so `docker stop` and Kubernetes pod termination only shut down
+	// cleanly because of this.
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- httpServer.Serve(listener)
+	}()
+
+	select {
+	case err := <-errCh:
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return fmt.Errorf("serve: %w", err)
+		}
+		return nil
+	case <-ctx.Done():
+		log.Info("shutdown signal received")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownGrace)
+		defer cancel()
+		if err := httpServer.Shutdown(shutdownCtx); err != nil {
+			return fmt.Errorf("shutdown: %w", err)
+		}
+		log.Info("stopped")
+		return nil
+	}
+}
+
+// healthcheck talks to the running server over the loopback interface and maps
+// the result onto the process exit code Docker expects.
+func healthcheck(addr string) error {
+	target, err := healthURL(addr)
+	if err != nil {
+		return err
+	}
+
+	client := &http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Get(target)
+	if err != nil {
+		return fmt.Errorf("healthcheck: %w", err)
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("healthcheck: unexpected status %s", resp.Status)
+	}
+	return nil
+}
+
+// healthURL turns a listen address into a loopback URL. A wildcard bind
+// (":8080" or "0.0.0.0:8080") is reachable on 127.0.0.1 from inside the
+// container, which is where the health check runs.
+func healthURL(addr string) (string, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return "", fmt.Errorf("parse listen address %q: %w", addr, err)
+	}
+	switch host {
+	case "", "0.0.0.0", "[::]", "::":
+		host = "127.0.0.1"
+	}
+	// JoinHostPort brackets IPv6 literals itself.
+	return "http://" + net.JoinHostPort(host, port) + healthPath, nil
+}

--- a/tool/webserver/server.go
+++ b/tool/webserver/server.go
@@ -3,6 +3,7 @@ package main
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/fs"
@@ -22,6 +23,15 @@ const indexFile = "index.html"
 // healthPath is answered by the server itself so the container needs no shell
 // and no curl for its health check.
 const healthPath = "/healthz"
+
+// configPath carries the settings the app cannot know at build time. Baking the
+// backend URL into the bundle would make the image environment-specific, so it
+// could not be promoted from staging to production - the app fetches this
+// instead, before it talks to any API.
+//
+// It is served by the server, not read from the bundle: a file of the same name
+// inside the bundle is shadowed by this endpoint.
+const configPath = "/config.json"
 
 // entryPoints are never cached beyond a revalidation, whatever
 // STELARIS_ASSET_CACHE_CONTROL says. A stale shell or service worker pins a
@@ -88,6 +98,14 @@ type Server struct {
 	assets  map[string]*asset
 	index   *asset
 	headers [][2]string // security headers, materialised once
+	config  []byte      // rendered /config.json body
+}
+
+// appConfig is the wire format of /config.json. The field names are the app's
+// contract - changing one means changing lib/env/runtime_config.dart too.
+type appConfig struct {
+	BackendURL   string `json:"backendUrl"`
+	GeneratorURL string `json:"generatorUrl"`
 }
 
 // NewServer indexes the bundle and precomputes every response header that does
@@ -106,6 +124,15 @@ func NewServer(fsys fs.FS, cfg Config, log *slog.Logger) (*Server, error) {
 	if s.index == nil {
 		return nil, fmt.Errorf("bundle contains no %s - was the Flutter web build copied into the image?", indexFile)
 	}
+	body, err := json.Marshal(appConfig{
+		BackendURL:   cfg.BackendURL,
+		GeneratorURL: cfg.GeneratorURL,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("render %s: %w", configPath, err)
+	}
+	s.config = body
+
 	s.headers = buildSecurityHeaders(cfg)
 	return s, nil
 }
@@ -253,6 +280,21 @@ func (s *Server) serve(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet && r.Method != http.MethodHead {
 		w.Header().Set("Allow", "GET, HEAD")
 		httpError(w, r, http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Answered before the bundle lookup so a stray config.json in the build
+	// output can never shadow the values this deployment was started with.
+	if r.URL.Path == configPath {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		// Never cached anywhere: a cached config outlives the deployment that
+		// produced it and silently points the app at the wrong backend.
+		w.Header().Set("Cache-Control", "no-store")
+		w.Header().Set("Content-Length", strconv.Itoa(len(s.config)))
+		w.WriteHeader(http.StatusOK)
+		if r.Method == http.MethodGet {
+			w.Write(s.config)
+		}
 		return
 	}
 

--- a/tool/webserver/server.go
+++ b/tool/webserver/server.go
@@ -1,0 +1,447 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/fs"
+	"log/slog"
+	"net/http"
+	"path"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// indexFile is the application shell. Every route that go_router owns resolves
+// to it, mirroring nginx's `try_files $uri $uri/ /index.html`.
+const indexFile = "index.html"
+
+// healthPath is answered by the server itself so the container needs no shell
+// and no curl for its health check.
+const healthPath = "/healthz"
+
+// entryPoints are never cached beyond a revalidation, whatever
+// STELARIS_ASSET_CACHE_CONTROL says. A stale shell or service worker pins a
+// browser to a build that no longer exists on the server, and that failure mode
+// is invisible until someone hard-reloads.
+var entryPoints = map[string]bool{
+	indexFile:                   true,
+	"flutter.js":                true,
+	"flutter_bootstrap.js":      true,
+	"flutter_service_worker.js": true,
+	"manifest.json":             true,
+	"version.json":              true,
+}
+
+// contentTypes is an explicit table instead of mime.TypeByExtension because a
+// scratch image has no /etc/mime.types, and because two of these are load
+// bearing: WebAssembly.instantiateStreaming rejects anything that is not
+// exactly application/wasm, and the .mjs entrypoint must be served as
+// JavaScript or the module import fails.
+var contentTypes = map[string]string{
+	".bin":     "application/octet-stream",
+	".css":     "text/css; charset=utf-8",
+	".html":    "text/html; charset=utf-8",
+	".ico":     "image/x-icon",
+	".jpg":     "image/jpeg",
+	".jpeg":    "image/jpeg",
+	".js":      "text/javascript; charset=utf-8",
+	".json":    "application/json; charset=utf-8",
+	".map":     "application/json; charset=utf-8",
+	".mjs":     "text/javascript; charset=utf-8",
+	".otf":     "font/otf",
+	".png":     "image/png",
+	".svg":     "image/svg+xml",
+	".symbols": "text/plain; charset=utf-8",
+	".ttf":     "font/ttf",
+	".txt":     "text/plain; charset=utf-8",
+	".wasm":    "application/wasm",
+	".webp":    "image/webp",
+	".woff":    "font/woff",
+	".woff2":   "font/woff2",
+	".xml":     "application/xml; charset=utf-8",
+}
+
+// asset holds everything about one bundle file that can be computed once. The
+// bundle is baked into the binary and therefore immutable for the lifetime of
+// the process, so nothing here is ever invalidated.
+type asset struct {
+	name         string // path inside the bundle, e.g. "assets/NOTICES"
+	gzipName     string // precompressed sibling, empty when there is none
+	contentType  string
+	cacheControl string
+	size         int64
+	gzipSize     int64
+	etag         string
+	gzipETag     string
+}
+
+// Server serves a compiled Flutter web bundle and nothing else: no directory
+// listings, no uploads, no proxying, no server-side templating.
+type Server struct {
+	fsys    fs.FS
+	cfg     Config
+	log     *slog.Logger
+	assets  map[string]*asset
+	index   *asset
+	headers [][2]string // security headers, materialised once
+}
+
+// NewServer indexes the bundle and precomputes every response header that does
+// not depend on the request.
+func NewServer(fsys fs.FS, cfg Config, log *slog.Logger) (*Server, error) {
+	s := &Server{
+		fsys:   fsys,
+		cfg:    cfg,
+		log:    log,
+		assets: make(map[string]*asset),
+	}
+
+	if err := s.indexBundle(); err != nil {
+		return nil, err
+	}
+	if s.index == nil {
+		return nil, fmt.Errorf("bundle contains no %s - was the Flutter web build copied into the image?", indexFile)
+	}
+	s.headers = buildSecurityHeaders(cfg)
+	return s, nil
+}
+
+// indexBundle walks the bundle once and fills the asset table.
+func (s *Server) indexBundle() error {
+	gzipped := make(map[string]int64)
+
+	err := fs.WalkDir(s.fsys, ".", func(name string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if strings.HasSuffix(name, ".gz") {
+			gzipped[strings.TrimSuffix(name, ".gz")] = info.Size()
+			return nil
+		}
+
+		sum, err := s.hash(name)
+		if err != nil {
+			return err
+		}
+		ext := strings.ToLower(path.Ext(name))
+		s.assets[name] = &asset{
+			name:         name,
+			contentType:  contentTypeFor(ext),
+			cacheControl: s.cacheControlFor(name),
+			size:         info.Size(),
+			etag:         `"` + sum + `"`,
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// Wire up the precompressed siblings produced at image build time.
+	for name, size := range gzipped {
+		a, ok := s.assets[name]
+		if !ok {
+			continue
+		}
+		a.gzipName = name + ".gz"
+		a.gzipSize = size
+		// A different encoding is a different representation and must not share
+		// an ETag, or a caching proxy can hand a gzip body to a client that did
+		// not ask for one.
+		a.gzipETag = strings.TrimSuffix(a.etag, `"`) + `-gz"`
+	}
+
+	s.index = s.assets[indexFile]
+	return nil
+}
+
+func (s *Server) hash(name string) (string, error) {
+	f, err := s.fsys.Open(name)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	// 128 bits of a SHA-256 is plenty for cache validation and keeps the header
+	// short.
+	return hex.EncodeToString(h.Sum(nil))[:32], nil
+}
+
+func (s *Server) cacheControlFor(name string) string {
+	if entryPoints[name] {
+		return "no-cache"
+	}
+	return s.cfg.AssetCacheControl
+}
+
+func contentTypeFor(ext string) string {
+	if ct, ok := contentTypes[ext]; ok {
+		return ct
+	}
+	// Flutter emits extensionless files (assets/NOTICES). Anything unknown is
+	// served as an opaque download rather than guessed at, and nosniff keeps the
+	// browser from second-guessing that.
+	return "application/octet-stream"
+}
+
+// buildSecurityHeaders materialises the headers that are identical on every
+// response, so the hot path is a slice append instead of a config lookup.
+func buildSecurityHeaders(cfg Config) [][2]string {
+	headers := [][2]string{
+		// The bundle's content types are exact (see contentTypes), so sniffing
+		// can only ever get it wrong.
+		{"X-Content-Type-Options", "nosniff"},
+		// Belt and braces with frame-ancestors for browsers that predate CSP3.
+		{"X-Frame-Options", "DENY"},
+		{"Referrer-Policy", "no-referrer"},
+		// The bundle is only ever loaded by its own origin.
+		{"Cross-Origin-Resource-Policy", "same-origin"},
+		{"Permissions-Policy", "accelerometer=(), autoplay=(), camera=(), display-capture=(), encrypted-media=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(), usb=()"},
+	}
+	if cfg.CSP != "" {
+		headers = append(headers, [2]string{"Content-Security-Policy", cfg.CSP})
+	}
+	if cfg.CrossOriginIsolation {
+		headers = append(headers,
+			[2]string{"Cross-Origin-Opener-Policy", "same-origin"},
+			[2]string{"Cross-Origin-Embedder-Policy", cfg.COEP},
+		)
+	}
+	return headers
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	start := time.Now()
+	rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+	s.serve(rec, r)
+
+	if s.cfg.AccessLog {
+		// The query string is deliberately not logged: it is attacker- and
+		// user-controlled and can carry tokens.
+		s.log.Info("request",
+			slog.String("method", r.Method),
+			slog.String("path", r.URL.Path),
+			slog.Int("status", rec.status),
+			slog.Int64("bytes", rec.written),
+			slog.Duration("duration", time.Since(start)),
+		)
+	}
+}
+
+func (s *Server) serve(w http.ResponseWriter, r *http.Request) {
+	for _, h := range s.headers {
+		w.Header().Set(h[0], h[1])
+	}
+
+	// A static bundle is read-only by definition. Anything that is not a read
+	// is rejected before it can touch the file lookup.
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		w.Header().Set("Allow", "GET, HEAD")
+		httpError(w, r, http.StatusMethodNotAllowed)
+		return
+	}
+
+	if r.URL.Path == healthPath {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.Header().Set("Cache-Control", "no-store")
+		w.WriteHeader(http.StatusOK)
+		if r.Method == http.MethodGet {
+			io.WriteString(w, "ok\n")
+		}
+		return
+	}
+
+	name, ok := bundlePath(r.URL.Path)
+	if !ok {
+		httpError(w, r, http.StatusBadRequest)
+		return
+	}
+
+	if a, found := s.assets[name]; found {
+		s.write(w, r, a, http.StatusOK)
+		return
+	}
+
+	// try_files $uri $uri/ /index.html: go_router owns every path that is not a
+	// file, so a deep link has to return the shell. A request that looks like a
+	// missing asset gets an honest 404 instead - answering those with HTML
+	// breaks streaming Wasm instantiation and hides broken builds.
+	if looksLikeAsset(name) {
+		httpError(w, r, http.StatusNotFound)
+		return
+	}
+	s.write(w, r, s.index, http.StatusOK)
+}
+
+// bundlePath maps a request path onto a path inside the bundle. It returns
+// false for paths that cannot be served at all.
+func bundlePath(urlPath string) (string, bool) {
+	if strings.ContainsRune(urlPath, 0) {
+		return "", false
+	}
+	if !strings.HasPrefix(urlPath, "/") {
+		urlPath = "/" + urlPath
+	}
+	// path.Clean resolves . and .. segments; because the result stays rooted at
+	// "/" it can never escape the bundle, and the FS is read-only anyway.
+	cleaned := path.Clean(urlPath)
+	if cleaned == "/" {
+		return indexFile, true
+	}
+	name := strings.TrimPrefix(cleaned, "/")
+	if name == "" || strings.HasPrefix(name, "../") {
+		return "", false
+	}
+	return name, true
+}
+
+// looksLikeAsset reports whether a miss should be a 404 rather than the app
+// shell. Anything with a file extension in its last segment is a file request.
+func looksLikeAsset(name string) bool {
+	return path.Ext(path.Base(name)) != ""
+}
+
+func (s *Server) write(w http.ResponseWriter, r *http.Request, a *asset, status int) {
+	useGzip := a.gzipName != "" && acceptsGzip(r)
+
+	etag := a.etag
+	size := a.size
+	if useGzip {
+		etag = a.gzipETag
+		size = a.gzipSize
+		w.Header().Set("Content-Encoding", "gzip")
+	}
+	if a.gzipName != "" {
+		w.Header().Set("Vary", "Accept-Encoding")
+	}
+
+	w.Header().Set("Content-Type", a.contentType)
+	w.Header().Set("Cache-Control", a.cacheControl)
+	w.Header().Set("ETag", etag)
+
+	if matchesETag(r.Header.Get("If-None-Match"), etag) {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+
+	w.Header().Set("Content-Length", strconv.FormatInt(size, 10))
+	w.WriteHeader(status)
+	if r.Method == http.MethodHead {
+		return
+	}
+
+	name := a.name
+	if useGzip {
+		name = a.gzipName
+	}
+	f, err := s.fsys.Open(name)
+	if err != nil {
+		// The table was built from this same FS at startup, so this only
+		// happens if the FS lied to us. The status line is already on the wire.
+		s.log.Error("open bundle file", slog.String("file", name), slog.Any("error", err))
+		return
+	}
+	defer f.Close()
+
+	if _, err := io.Copy(w, f); err != nil {
+		s.log.Debug("write response", slog.String("file", name), slog.Any("error", err))
+	}
+}
+
+func acceptsGzip(r *http.Request) bool {
+	for _, part := range strings.Split(r.Header.Get("Accept-Encoding"), ",") {
+		token, params, _ := strings.Cut(strings.TrimSpace(part), ";")
+		if !strings.EqualFold(strings.TrimSpace(token), "gzip") {
+			continue
+		}
+		// "gzip;q=0" is an explicit refusal.
+		if q, ok := strings.CutPrefix(strings.TrimSpace(params), "q="); ok {
+			if v, err := strconv.ParseFloat(strings.TrimSpace(q), 64); err == nil && v == 0 {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+func matchesETag(header, etag string) bool {
+	if header == "" {
+		return false
+	}
+	for _, candidate := range strings.Split(header, ",") {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "*" || candidate == etag {
+			return true
+		}
+		// A weak validator still identifies the same representation.
+		if strings.TrimPrefix(candidate, "W/") == etag {
+			return true
+		}
+	}
+	return false
+}
+
+// httpError answers with a bare text body: no stack traces, no paths, no
+// Go version, nothing that describes the server.
+func httpError(w http.ResponseWriter, r *http.Request, status int) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Del("Content-Encoding")
+	w.WriteHeader(status)
+	if r.Method != http.MethodHead {
+		fmt.Fprintln(w, http.StatusText(status))
+	}
+}
+
+// statusRecorder captures what was actually sent, for the access log.
+type statusRecorder struct {
+	http.ResponseWriter
+	status  int
+	written int64
+	wrote   bool
+}
+
+func (s *statusRecorder) WriteHeader(status int) {
+	if s.wrote {
+		return
+	}
+	s.wrote = true
+	s.status = status
+	s.ResponseWriter.WriteHeader(status)
+}
+
+func (s *statusRecorder) Write(b []byte) (int, error) {
+	if !s.wrote {
+		s.WriteHeader(http.StatusOK)
+	}
+	n, err := s.ResponseWriter.Write(b)
+	s.written += int64(n)
+	return n, err
+}
+
+// bundleFiles lists the indexed files, sorted. Used by the startup log so an
+// operator can see what actually made it into the image.
+func (s *Server) bundleFiles() []string {
+	names := make([]string, 0, len(s.assets))
+	for name := range s.assets {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/tool/webserver/server_test.go
+++ b/tool/webserver/server_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"compress/gzip"
+	"encoding/json"
 	"io"
 	"io/fs"
 	"log/slog"
@@ -343,6 +344,91 @@ func TestHealthEndpoint(t *testing.T) {
 	}
 	if !strings.HasPrefix(rec.Body.String(), "ok") {
 		t.Errorf("body = %q", rec.Body.String())
+	}
+}
+
+func TestConfigEndpoint(t *testing.T) {
+	cfg := testConfig()
+	cfg.BackendURL = "https://api.stelaris.example"
+	cfg.GeneratorURL = "https://generator.stelaris.example"
+	srv := newTestServer(t, cfg)
+
+	rec := do(t, srv, http.MethodGet, configPath, nil)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json; charset=utf-8" {
+		t.Errorf("Content-Type = %q", got)
+	}
+	// A cached config outlives the deployment that produced it.
+	if got := rec.Header().Get("Cache-Control"); got != "no-store" {
+		t.Errorf("Cache-Control = %q, want no-store", got)
+	}
+
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("body is not JSON: %v (%s)", err, rec.Body.String())
+	}
+	// These keys are the contract with lib/env/runtime_config.dart.
+	if body["backendUrl"] != cfg.BackendURL {
+		t.Errorf("backendUrl = %q, want %q", body["backendUrl"], cfg.BackendURL)
+	}
+	if body["generatorUrl"] != cfg.GeneratorURL {
+		t.Errorf("generatorUrl = %q, want %q", body["generatorUrl"], cfg.GeneratorURL)
+	}
+}
+
+// The endpoint must win over the bundle, or a stale config.json shipped in a
+// build would silently override what the deployment was started with.
+func TestConfigEndpointShadowsBundleFile(t *testing.T) {
+	bundle := fstest.MapFS{
+		"index.html":  {Data: []byte(indexBody)},
+		"config.json": {Data: []byte(`{"backendUrl":"https://stale.example"}`)},
+	}
+	cfg := testConfig()
+	cfg.BackendURL = "https://live.example"
+	srv, err := NewServer(bundle, cfg, slog.New(slog.DiscardHandler))
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	rec := do(t, srv, http.MethodGet, configPath, nil)
+
+	if strings.Contains(rec.Body.String(), "stale.example") {
+		t.Errorf("bundle config.json shadowed the live one: %s", rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "live.example") {
+		t.Errorf("body = %s", rec.Body.String())
+	}
+}
+
+func TestConfigEndpointHeadHasNoBody(t *testing.T) {
+	srv := newTestServer(t, testConfig())
+
+	rec := do(t, srv, http.MethodHead, configPath, nil)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("HEAD returned %d body bytes", rec.Body.Len())
+	}
+}
+
+func TestConfigEndpointWithoutConfiguration(t *testing.T) {
+	srv := newTestServer(t, testConfig())
+
+	rec := do(t, srv, http.MethodGet, configPath, nil)
+
+	// Still valid JSON with empty values: the app then keeps its compiled-in
+	// defaults instead of choking on a malformed response.
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("body is not JSON: %v", err)
+	}
+	if body["backendUrl"] != "" {
+		t.Errorf("backendUrl = %q, want empty", body["backendUrl"])
 	}
 }
 

--- a/tool/webserver/server_test.go
+++ b/tool/webserver/server_test.go
@@ -1,0 +1,384 @@
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"io/fs"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+const indexBody = "<!DOCTYPE html><html><body>shell</body></html>"
+
+func gzipBytes(t *testing.T, in string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	if _, err := io.WriteString(w, in); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// testBundle mirrors the shape of a real `flutter build web --wasm` output:
+// an entry point, a Wasm module, an extensionless asset and a precompressed
+// sibling.
+func testBundle(t *testing.T) fs.FS {
+	t.Helper()
+	return fstest.MapFS{
+		"index.html":                {Data: []byte(indexBody)},
+		"index.html.gz":             {Data: gzipBytes(t, indexBody)},
+		"flutter_service_worker.js": {Data: []byte("// sw")},
+		"main.dart.wasm":            {Data: []byte("\x00asm")},
+		"main.dart.mjs":             {Data: []byte("export default 1;")},
+		"assets/NOTICES":            {Data: []byte("licenses")},
+		"canvaskit/canvaskit.wasm":  {Data: []byte("\x00asm")},
+	}
+}
+
+func newTestServer(t *testing.T, cfg Config) *Server {
+	t.Helper()
+	srv, err := NewServer(testBundle(t), cfg, slog.New(slog.DiscardHandler))
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	return srv
+}
+
+func testConfig() Config {
+	cfg := LoadConfig(func(string) (string, bool) { return "", false })
+	cfg.AccessLog = false
+	return cfg
+}
+
+func do(t *testing.T, srv *Server, method, target string, headers map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, target, nil)
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestServesIndexForRoot(t *testing.T) {
+	srv := newTestServer(t, testConfig())
+
+	rec := do(t, srv, http.MethodGet, "/", nil)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Body.String(); got != indexBody {
+		t.Errorf("body = %q, want the app shell", got)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "text/html; charset=utf-8" {
+		t.Errorf("Content-Type = %q", got)
+	}
+	if got := rec.Header().Get("Cache-Control"); got != "no-cache" {
+		t.Errorf("Cache-Control = %q, entry points must revalidate", got)
+	}
+}
+
+// go_router owns client-side routes, so a deep link must return the shell with
+// a 200 instead of a 404.
+func TestDeepLinkFallsBackToShell(t *testing.T) {
+	srv := newTestServer(t, testConfig())
+
+	for _, target := range []string{"/items", "/items/42", "/build/generate", "/some/deep/route/"} {
+		rec := do(t, srv, http.MethodGet, target, nil)
+		if rec.Code != http.StatusOK {
+			t.Errorf("%s: status = %d, want 200", target, rec.Code)
+		}
+		if rec.Body.String() != indexBody {
+			t.Errorf("%s: did not serve the app shell", target)
+		}
+	}
+}
+
+// A missing file must stay a 404. Answering it with HTML would break streaming
+// Wasm instantiation and hide broken builds behind a working-looking page.
+func TestMissingAssetIsNotFound(t *testing.T) {
+	srv := newTestServer(t, testConfig())
+
+	for _, target := range []string{"/missing.wasm", "/canvaskit/gone.js", "/assets/nope.png"} {
+		rec := do(t, srv, http.MethodGet, target, nil)
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("%s: status = %d, want 404", target, rec.Code)
+		}
+	}
+}
+
+func TestContentTypes(t *testing.T) {
+	srv := newTestServer(t, testConfig())
+
+	cases := map[string]string{
+		// instantiateStreaming refuses anything but application/wasm.
+		"/main.dart.wasm":           "application/wasm",
+		"/canvaskit/canvaskit.wasm": "application/wasm",
+		"/main.dart.mjs":            "text/javascript; charset=utf-8",
+		// Flutter emits this without an extension.
+		"/assets/NOTICES": "application/octet-stream",
+	}
+	for target, want := range cases {
+		rec := do(t, srv, http.MethodGet, target, nil)
+		if got := rec.Header().Get("Content-Type"); got != want {
+			t.Errorf("%s: Content-Type = %q, want %q", target, got, want)
+		}
+	}
+}
+
+func TestOnlyReadMethodsAllowed(t *testing.T) {
+	srv := newTestServer(t, testConfig())
+
+	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch} {
+		rec := do(t, srv, method, "/", nil)
+		if rec.Code != http.StatusMethodNotAllowed {
+			t.Errorf("%s: status = %d, want 405", method, rec.Code)
+		}
+		if got := rec.Header().Get("Allow"); got != "GET, HEAD" {
+			t.Errorf("%s: Allow = %q", method, got)
+		}
+	}
+}
+
+func TestHeadHasHeadersButNoBody(t *testing.T) {
+	srv := newTestServer(t, testConfig())
+
+	rec := do(t, srv, http.MethodHead, "/main.dart.wasm", nil)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("HEAD returned %d body bytes", rec.Body.Len())
+	}
+	if got := rec.Header().Get("Content-Length"); got != "4" {
+		t.Errorf("Content-Length = %q, want 4", got)
+	}
+}
+
+// The bundle FS is rooted, so traversal cannot escape it - but it must also not
+// silently succeed with something unexpected.
+func TestPathTraversalCannotEscapeBundle(t *testing.T) {
+	srv := newTestServer(t, testConfig())
+
+	for _, target := range []string{"/../../etc/passwd", "/..%2f..%2fetc%2fpasswd", "/./../../index.html"} {
+		rec := do(t, srv, http.MethodGet, target, nil)
+		body := rec.Body.String()
+		if strings.Contains(body, "root:") {
+			t.Fatalf("%s: leaked host file content", target)
+		}
+		if rec.Code != http.StatusOK && rec.Code != http.StatusNotFound && rec.Code != http.StatusBadRequest {
+			t.Errorf("%s: unexpected status %d", target, rec.Code)
+		}
+	}
+}
+
+func TestSecurityHeaders(t *testing.T) {
+	srv := newTestServer(t, testConfig())
+
+	rec := do(t, srv, http.MethodGet, "/", nil)
+
+	want := map[string]string{
+		"X-Content-Type-Options":       "nosniff",
+		"X-Frame-Options":              "DENY",
+		"Referrer-Policy":              "no-referrer",
+		"Cross-Origin-Resource-Policy": "same-origin",
+	}
+	for header, value := range want {
+		if got := rec.Header().Get(header); got != value {
+			t.Errorf("%s = %q, want %q", header, got, value)
+		}
+	}
+	if got := rec.Header().Get("Permissions-Policy"); !strings.Contains(got, "camera=()") {
+		t.Errorf("Permissions-Policy = %q", got)
+	}
+
+	csp := rec.Header().Get("Content-Security-Policy")
+	// Without these the Flutter engine does not start at all, so they are as
+	// much a functional contract as a security one.
+	for _, directive := range []string{"'wasm-unsafe-eval'", "worker-src 'self' blob:", "frame-ancestors 'none'", "connect-src 'self' https:"} {
+		if !strings.Contains(csp, directive) {
+			t.Errorf("CSP is missing %q: %s", directive, csp)
+		}
+	}
+}
+
+func TestCrossOriginIsolationIsOptIn(t *testing.T) {
+	off := newTestServer(t, testConfig())
+	rec := do(t, off, http.MethodGet, "/", nil)
+	if got := rec.Header().Get("Cross-Origin-Opener-Policy"); got != "" {
+		t.Errorf("COOP = %q, want unset by default", got)
+	}
+
+	cfg := testConfig()
+	cfg.CrossOriginIsolation = true
+	on := newTestServer(t, cfg)
+	rec = do(t, on, http.MethodGet, "/", nil)
+	if got := rec.Header().Get("Cross-Origin-Opener-Policy"); got != "same-origin" {
+		t.Errorf("COOP = %q, want same-origin", got)
+	}
+	if got := rec.Header().Get("Cross-Origin-Embedder-Policy"); got != "credentialless" {
+		t.Errorf("COEP = %q, want credentialless", got)
+	}
+}
+
+func TestCSPCanBeDisabled(t *testing.T) {
+	cfg := testConfig()
+	cfg.CSP = ""
+	srv := newTestServer(t, cfg)
+
+	rec := do(t, srv, http.MethodGet, "/", nil)
+
+	if got := rec.Header().Get("Content-Security-Policy"); got != "" {
+		t.Errorf("CSP = %q, want no header", got)
+	}
+}
+
+func TestETagRevalidation(t *testing.T) {
+	srv := newTestServer(t, testConfig())
+
+	first := do(t, srv, http.MethodGet, "/main.dart.wasm", nil)
+	etag := first.Header().Get("ETag")
+	if etag == "" {
+		t.Fatal("no ETag on first response")
+	}
+
+	second := do(t, srv, http.MethodGet, "/main.dart.wasm", map[string]string{"If-None-Match": etag})
+	if second.Code != http.StatusNotModified {
+		t.Errorf("status = %d, want 304", second.Code)
+	}
+	if second.Body.Len() != 0 {
+		t.Errorf("304 carried %d body bytes", second.Body.Len())
+	}
+
+	weak := do(t, srv, http.MethodGet, "/main.dart.wasm", map[string]string{"If-None-Match": "W/" + etag})
+	if weak.Code != http.StatusNotModified {
+		t.Errorf("weak validator: status = %d, want 304", weak.Code)
+	}
+}
+
+func TestPrecompressedVariant(t *testing.T) {
+	srv := newTestServer(t, testConfig())
+
+	compressed := do(t, srv, http.MethodGet, "/", map[string]string{"Accept-Encoding": "gzip, deflate, br"})
+	if got := compressed.Header().Get("Content-Encoding"); got != "gzip" {
+		t.Fatalf("Content-Encoding = %q, want gzip", got)
+	}
+	if got := compressed.Header().Get("Vary"); got != "Accept-Encoding" {
+		t.Errorf("Vary = %q", got)
+	}
+	length, err := strconv.Atoi(compressed.Header().Get("Content-Length"))
+	if err != nil || length != compressed.Body.Len() {
+		t.Errorf("Content-Length = %q, body = %d bytes", compressed.Header().Get("Content-Length"), compressed.Body.Len())
+	}
+	gz, err := gzip.NewReader(bytes.NewReader(compressed.Body.Bytes()))
+	if err != nil {
+		t.Fatalf("response is not valid gzip: %v", err)
+	}
+	decoded, err := io.ReadAll(gz)
+	if err != nil {
+		t.Fatalf("gzip read: %v", err)
+	}
+	if string(decoded) != indexBody {
+		t.Errorf("decompressed body = %q", decoded)
+	}
+
+	plain := do(t, srv, http.MethodGet, "/", nil)
+	if got := plain.Header().Get("Content-Encoding"); got != "" {
+		t.Errorf("Content-Encoding = %q without Accept-Encoding", got)
+	}
+	if plain.Body.String() != indexBody {
+		t.Errorf("uncompressed body = %q", plain.Body.String())
+	}
+
+	// A shared ETag across encodings lets a proxy hand a gzip body to a client
+	// that never asked for one.
+	if compressed.Header().Get("ETag") == plain.Header().Get("ETag") {
+		t.Error("gzip and identity responses share an ETag")
+	}
+}
+
+func TestGzipRefusedWithQualityZero(t *testing.T) {
+	srv := newTestServer(t, testConfig())
+
+	rec := do(t, srv, http.MethodGet, "/", map[string]string{"Accept-Encoding": "gzip;q=0"})
+
+	if got := rec.Header().Get("Content-Encoding"); got != "" {
+		t.Errorf("Content-Encoding = %q, client refused gzip", got)
+	}
+}
+
+func TestGzipSiblingIsNotServedDirectly(t *testing.T) {
+	srv := newTestServer(t, testConfig())
+
+	rec := do(t, srv, http.MethodGet, "/index.html.gz", nil)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 - the .gz sibling is an implementation detail", rec.Code)
+	}
+}
+
+func TestHealthEndpoint(t *testing.T) {
+	srv := newTestServer(t, testConfig())
+
+	rec := do(t, srv, http.MethodGet, healthPath, nil)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("Cache-Control"); got != "no-store" {
+		t.Errorf("Cache-Control = %q", got)
+	}
+	if !strings.HasPrefix(rec.Body.String(), "ok") {
+		t.Errorf("body = %q", rec.Body.String())
+	}
+}
+
+func TestAssetCacheControlDoesNotApplyToEntryPoints(t *testing.T) {
+	cfg := testConfig()
+	cfg.AssetCacheControl = "public, max-age=31536000, immutable"
+	srv := newTestServer(t, cfg)
+
+	asset := do(t, srv, http.MethodGet, "/main.dart.wasm", nil)
+	if got := asset.Header().Get("Cache-Control"); got != cfg.AssetCacheControl {
+		t.Errorf("asset Cache-Control = %q, want %q", got, cfg.AssetCacheControl)
+	}
+
+	for _, entry := range []string{"/", "/flutter_service_worker.js"} {
+		rec := do(t, srv, http.MethodGet, entry, nil)
+		if got := rec.Header().Get("Cache-Control"); got != "no-cache" {
+			t.Errorf("%s: Cache-Control = %q, want no-cache", entry, got)
+		}
+	}
+}
+
+func TestBundleWithoutIndexIsRejected(t *testing.T) {
+	_, err := NewServer(fstest.MapFS{"main.dart.js": {Data: []byte("x")}}, testConfig(), slog.New(slog.DiscardHandler))
+
+	if err == nil {
+		t.Fatal("expected an error for a bundle without index.html")
+	}
+}
+
+// The image is only useful if the bundle actually made it into the binary.
+func TestEmbeddedBundleContainsIndex(t *testing.T) {
+	webroot, err := fs.Sub(bundleFS, "webroot")
+	if err != nil {
+		t.Fatalf("fs.Sub: %v", err)
+	}
+	if _, err := fs.Stat(webroot, indexFile); err != nil {
+		t.Fatalf("embedded bundle has no %s: %v", indexFile, err)
+	}
+}

--- a/tool/webserver/webroot/index.html
+++ b/tool/webserver/webroot/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<!--
+  Placeholder web root.
+
+  The production image replaces this directory with the output of
+  `flutter build web --release --wasm` before the binary is compiled, so the
+  real bundle is what ends up embedded. This file only exists so the Go package
+  builds, tests and `go run .` work without a Flutter toolchain present.
+-->
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Stelaris UI - placeholder bundle</title>
+</head>
+<body>
+<h1>Stelaris UI</h1>
+<p>
+    This binary was built without a Flutter web bundle. Run
+    <code>flutter build web --release --wasm</code> and rebuild the image so the
+    real application is embedded.
+</p>
+</body>
+</html>


### PR DESCRIPTION
## Proposed changes

Ship the UI from a `FROM scratch` image instead of nginx. The runtime image
contains **one file**: a statically linked Go binary with the compiled Flutter
web bundle embedded in it.

```
$ docker export $(docker create stelaris-ui) | tar -t
stelaris-ui
```

nginx is a reverse proxy, load balancer, TLS terminator and FastCGI gateway that
also serves static files. We only need the last part; the rest is attack surface
we have to keep patched forever. Replacing it removes the shell, the package
manager and every OS package from the image.

Measured against the image this replaces:

| | `nginx:1.31.4-alpine` | this PR |
| --- | --- | --- |
| OS packages | 71 | 0 |
| Files in the image | 2130 | 1 |
| Executables in `bin`/`sbin` | 340 | 1 |
| Image size, same 45 MB bundle | 42.0 MB | 19.9 MB (precompressed copies included) |
| Shell available to an attacker | `/bin/sh` | none |
| Runs as | root, workers drop to `nginx` | uid 65532, never root |
| Port | 80 (privileged) | 8080 (unprivileged) |

Both images report zero known CVEs today — the point is not today's count but
how much software has to stay CVE-free. Here that is the Go standard library
plus ~400 lines of our own code, and Renovate already keeps the pinned
`golang:1.26.7-alpine` builder current.

**This also fixes a broken build:** the current `Dockerfile` copies an
`nginx.conf` that no longer exists in the tree, so `docker build` fails on
`develop` today.

### Why a server at all

Serving HTTP needs *something* that speaks HTTP. The goal was the smallest thing
that can, so the server is standard library only — no third-party modules, no
`go.sum`, no config file to read at runtime. It answers `GET` and `HEAD` for the
embedded bundle and nothing else: no directory listings, no writable path, no
proxying, no scripting.

If the UI ever moves behind something that serves static files itself (a CDN, an
ingress with a static backend), the server becomes unnecessary and the build
stage already produces the bundle as plain files. That part is deliberately easy
to delete.

Alternatives weighed (full write-up in `docs/docker-image.md`): keeping nginx,
distroless + a static server, a third-party static server binary
(`static-web-server`, `darkhttpd`, Caddy), and a bundle-only image with no
server. Dart was ruled out because `dart compile exe` links against glibc and
cannot run in an image without libc.

### Behaviour it has to preserve

- **Deep links.** `go_router` owns any path that is not a file, so a miss falls
  back to `index.html` with a 200 — the same as nginx's
  `try_files $uri $uri/ /index.html`. A request that *looks* like a file (has an
  extension) still 404s, so broken builds stay visible instead of being served
  a HTML page.
- **`application/wasm`.** `WebAssembly.instantiateStreaming` rejects anything
  else, and a scratch image has no `/etc/mime.types`, so the content types are
  an explicit table.
- **Caching.** Flutter does not content-hash its output names
  (`main.dart.wasm` keeps its name across builds), so the default is `no-cache`
  with a strong content-derived `ETag`: revalidation costs a 304 and no body,
  and nobody gets pinned to a build that no longer exists. Entry points always
  revalidate.
- **Compression.** Text assets are gzipped once at image build time and served
  under their own `ETag`. Brotli would compress better but is not in the
  standard library, and a dependency is the worse trade here.

### Security headers

`X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`,
`Cross-Origin-Resource-Policy`, `Permissions-Policy` and a CSP on every response.

The default CSP is the strictest policy a Flutter bundle actually runs under,
not the strictest a browser accepts — it needs `'unsafe-inline'` (inline
bootstrap scripts in `web/index.html`, and Flutter's loader does not support
nonces, flutter/flutter#167800) and `'unsafe-eval'` / `'wasm-unsafe-eval'`
(CanvasKit and the Wasm entrypoint compile at runtime, flutter/flutter#127658).
`connect-src` is configurable because it has to allow the backend.

COOP/COEP are **off by default**. They only buy multi-threaded Wasm rendering,
they break cross-origin resources that do not opt into CORP/CORS, and
multi-threaded Skwasm currently renders a blank page under Chrome 146 with
isolation on (flutter/flutter#184843, still open). One env var turns them on
once that is fixed.

### Configuration

All environment variables, no files: `STELARIS_ADDR`, `STELARIS_CSP`,
`STELARIS_CONNECT_SRC`, `STELARIS_CROSS_ORIGIN_ISOLATION`, `STELARIS_COEP`,
`STELARIS_ASSET_CACHE_CONTROL`, `STELARIS_ACCESS_LOG`. Documented in
`docs/docker-image.md`.

### Verified

Against the **real bundle CI built** for this branch (`flutter build web
--release --wasm`, 45 MB, 39 files), pulled down and run locally:

- `main.dart.wasm` (3.3 MB) and `canvaskit/skwasm.wasm` (3.6 MB) served as
  `application/wasm`; `.mjs`, `assets/AssetManifest.bin.json`, `NOTICES`, icons
  and `version.json` all correct.
- Deep link `/items/deep/link` returns the shell; `/gone.js` returns 404.
- gzip: `main.dart.js` 3.62 MB -> 1.03 MB, `NOTICES` 1.47 MB -> 138 KB.
- `If-None-Match` on `main.dart.wasm` -> 304.
- Image with that bundle: **19.9 MB vs 42.0 MB** for the same bundle on
  `nginx:1.31.4-alpine` - smaller despite also carrying the precompressed copies.

Plus:

- `go test -race` - 20 tests covering routing, fallback, methods, traversal,
  content types, ETag/304, gzip negotiation, cache rules and header config.
- Runs under `--read-only --cap-drop=ALL --security-opt no-new-privileges
  --user 12345:12345`: no capability and no writable path needed.
- `docker stop` shuts down in ~0.1 s (the binary is PID 1 and handles `SIGTERM`
  itself) instead of waiting out the grace period.
- Docker `HEALTHCHECK` reports `healthy` - the binary health-checks itself over
  loopback, since the image has no shell or curl. Kubernetes can probe
  `GET /healthz`.
- `trivy image` - 0 vulnerabilities.
- `/config.json` serves the configured URLs with `no-store`, and the CSP came
  back as `connect-src 'self' https://api.stelaris.example https://gen.stelaris.example`.
- 30 Go tests and 71 Dart tests (8 of them new, for the config loader) pass in CI.

What is *not* verified: the app actually booting in a browser. That needs a
deployed environment with the backend reachable.

### Runtime configuration, not build-time

`Environment.backendURl` is an empty `const` with a comment saying the pipeline
should replace it - and no pipeline ever did, so the image would have shipped
with no backend at all. Replacing it at build time would also make the image
environment-specific, which defeats building once and promoting from staging to
production.

The server renders `/config.json` from its own environment instead:

```
GET /config.json          Cache-Control: no-store
{"backendUrl":"https://api.stelaris.example/v1","generatorUrl":"..."}
```

`RuntimeConfig.load()` runs in `main()` before anything talks to an API, and
`ApiService` reads `RuntimeConfig.current`.

- **`environment.dart` is untouched** - CONTRIBUTING forbids changing it. It
  stays the source for a local `flutter run`, and every field the served config
  leaves empty falls back to it.
- **Never fatal.** Missing, unreachable or malformed config -> the app starts on
  the compiled-in defaults rather than not starting at all.
- **The endpoint wins over the bundle**, so a stale `config.json` in a build
  cannot override a live deployment.
- **`no-store`**, because a cached config outlives the deployment that produced
  it and then points the app at the wrong backend.
- **The CSP follows the config**: `connect-src` is derived from those same URLs,
  so the policy cannot drift away from the configuration and quietly block the
  backend.

### Publishing through the org-wide chunked workflow

The `docker` job now delegates to
`OneLiteFeatherNET/workflows/.github/workflows/docker-publish.yml@v2.8.1`.
Harbor sits behind a proxy that caps request bodies at 100 MB and a plain
`docker push` sends each layer as one request, so `regctl` splits blobs above
50 MiB into several `PATCH` requests. The image is keyless-signed via OIDC.

The `flutter` job assembles `Dockerfile` + `tool/webserver` + `build/web` into a
`docker-context` artifact, so the shared workflow needs no Flutter knowledge.

Tags: a `v*.*.*` tag publishes that version; every other push publishes
`<manifest-version>-<branch-slug>` plus an immutable `sha-<short>`. Branch builds
are prereleases, so they never take over the `1`/`1.0` aliases of a release.

### Not in this PR

`security.yml` scans the filesystem, not the published image. Adding an image
scan to it is a sensible follow-up but out of scope here.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

Not breaking for the application, but it changes the deployment contract: the
container now listens on **8080** instead of **80**. Service/ingress definitions
need the new port.

## Checklist

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

`tool/webserver/webroot/` holds a placeholder page so the Go package builds,
tests and runs without a Flutter toolchain present. The Docker build deletes it
and copies the real `build/web` in its place before compiling, so nothing from
the placeholder can reach a published image.
