### PR TITLE
feat(helm): add a chart that deploys the UI to Kubernetes

### DIFF
--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -54,3 +54,39 @@ jobs:
           context: .
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  # helm unittest asserts on the rendered templates directly - that the pod
+  # really is unprivileged and read-only, that the runtime config is not
+  # mounted with subPath - which rendering and grepping never did reliably.
+  # ct lints the chart once per file in charts/stelaris-ui/ci/.
+  chart:
+    if: github.repository_owner == 'OneLiteFeatherNET'
+    name: Check the Helm chart
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          # ct lints what changed against the target branch, so it needs the
+          # history to compare with.
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v5.0.1
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.8.0
+
+      - name: Lint
+        run: ct lint --config ct.yaml
+
+      # Pinned rather than tracking HEAD: a plugin that changes under CI turns
+      # an unrelated pull request red. Renovate keeps the pin current.
+      # renovate: datasource=github-tags depName=helm-unittest/helm-unittest
+      - name: Install the unittest plugin
+        env:
+          UNITTEST_VERSION: v1.1.2
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version "$UNITTEST_VERSION" --verify=false
+
+      - name: Unit tests
+        run: helm unittest charts/stelaris-ui

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -117,13 +117,14 @@ jobs:
           PASSWORD: ${{ secrets.HARBOR_PASSWORD }}
         run: printf '%s' "$PASSWORD" | helm registry login "$REGISTRY" --username "$USERNAME" --password-stdin
 
-      # Into the same project as the image, so `helm show chart` and
-      # `docker pull` name the same place.
+      # Into the same Harbor project as the image, under charts/ - the layout
+      # Apus already uses, so a Flux OCIRepository pointing here looks like
+      # every other one in the cluster repository.
       - name: Push
         env:
           REGISTRY: ${{ secrets.HARBOR_REGISTRY }}
           VERSION: ${{ needs.release-please.outputs.version }}
-        run: helm push "dist/stelaris-ui-${VERSION}.tgz" "oci://${REGISTRY}/stelaris"
+        run: helm push "dist/stelaris-ui-${VERSION}.tgz" "oci://${REGISTRY}/onelitefeather/charts"
 
       - name: Log out
         if: always()

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -90,25 +90,14 @@ jobs:
           ref: ${{ needs.release-please.outputs.tag_name }}
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4.3.1
+        uses: azure/setup-helm@v5.0.1
 
-      # Release Please keeps Chart.yaml's version and appVersion current, so
-      # this only has to catch the case where that did not happen - publishing a
-      # chart that points at an image tag nobody built is worse than not
-      # publishing one.
-      - name: Check the chart version matches the release
-        env:
-          VERSION: ${{ needs.release-please.outputs.version }}
-        run: |
-          set -euo pipefail
-          CHART_VERSION="$(helm show chart charts/stelaris-ui | awk '/^version:/ {print $2}')"
-          APP_VERSION="$(helm show chart charts/stelaris-ui | awk '/^appVersion:/ {print $2}' | tr -d '"')"
-          echo "release=$VERSION chart=$CHART_VERSION app=$APP_VERSION"
-          test "$CHART_VERSION" = "$VERSION"
-          test "$APP_VERSION" = "$VERSION"
-
+      # Both versions come from the release rather than from Chart.yaml.
+      # Release Please keeps that file current anyway, but stating them here
+      # makes a mismatch impossible instead of something to check for: the
+      # chart cannot be packaged pointing at an image tag nobody built.
       - name: Package
-        run: helm package charts/stelaris-ui --destination dist
+        run: helm package charts/stelaris-ui --destination dist --version "${{ needs.release-please.outputs.version }}" --app-version "${{ needs.release-please.outputs.version }}"
 
       - name: Log in to OneLiteFeather Harbor
         env:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -68,3 +68,65 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.release-please.outputs.tag_name }}
         run: gh release upload "$TAG" bom.json --clobber
+
+  # Chained into this run rather than triggered by the tag, for the reason at
+  # the top of this file: release-please tags with GITHUB_TOKEN, and such a tag
+  # starts no `on: push: tags` workflow.
+  #
+  # Charts are published on a release only. A branch build is deployed by
+  # pointing an existing release of the chart at the branch's image tag, which
+  # needs no chart of its own.
+  helm:
+    name: Publish the Helm chart
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4.3.1
+
+      # Release Please keeps Chart.yaml's version and appVersion current, so
+      # this only has to catch the case where that did not happen - publishing a
+      # chart that points at an image tag nobody built is worse than not
+      # publishing one.
+      - name: Check the chart version matches the release
+        env:
+          VERSION: ${{ needs.release-please.outputs.version }}
+        run: |
+          set -euo pipefail
+          CHART_VERSION="$(helm show chart charts/stelaris-ui | awk '/^version:/ {print $2}')"
+          APP_VERSION="$(helm show chart charts/stelaris-ui | awk '/^appVersion:/ {print $2}' | tr -d '"')"
+          echo "release=$VERSION chart=$CHART_VERSION app=$APP_VERSION"
+          test "$CHART_VERSION" = "$VERSION"
+          test "$APP_VERSION" = "$VERSION"
+
+      - name: Package
+        run: helm package charts/stelaris-ui --destination dist
+
+      - name: Log in to OneLiteFeather Harbor
+        env:
+          REGISTRY: ${{ secrets.HARBOR_REGISTRY }}
+          USERNAME: ${{ secrets.HARBOR_USERNAME }}
+          PASSWORD: ${{ secrets.HARBOR_PASSWORD }}
+        run: printf '%s' "$PASSWORD" | helm registry login "$REGISTRY" --username "$USERNAME" --password-stdin
+
+      # Into the same project as the image, so `helm show chart` and
+      # `docker pull` name the same place.
+      - name: Push
+        env:
+          REGISTRY: ${{ secrets.HARBOR_REGISTRY }}
+          VERSION: ${{ needs.release-please.outputs.version }}
+        run: helm push "dist/stelaris-ui-${VERSION}.tgz" "oci://${REGISTRY}/stelaris"
+
+      - name: Log out
+        if: always()
+        env:
+          REGISTRY: ${{ secrets.HARBOR_REGISTRY }}
+        run: helm registry logout "$REGISTRY" || true

--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ health checks and how the image is published to Harbor — is in
 ## Deploying it to Kubernetes
 
 The Helm chart in [charts/stelaris-ui](charts/stelaris-ui) is published as an
-OCI artifact to the same Harbor project as the image, and its version always
-matches the image it deploys:
+OCI artifact into the same Harbor project as the image, under `charts/`, and
+its version always matches the image it deploys:
 
 ```sh
-helm install stelaris-ui oci://registry.onelitefeather.dev/stelaris/stelaris-ui \
+helm install stelaris-ui oci://harbor.onelitefeather.dev/onelitefeather/charts/stelaris-ui \
   --version 1.0.0 \
   --namespace stelaris --create-namespace \
   --set config.backendUrl=https://api.stelaris.example/v1 \

--- a/README.md
+++ b/README.md
@@ -51,6 +51,26 @@ The full picture — what the nginx config turns off and why, the CSP, caching,
 health checks and how the image is published to Harbor — is in
 [docs/docker-image.md](docs/docker-image.md).
 
+## Deploying it to Kubernetes
+
+The Helm chart in [charts/stelaris-ui](charts/stelaris-ui) is published as an
+OCI artifact to the same Harbor project as the image, and its version always
+matches the image it deploys:
+
+```sh
+helm install stelaris-ui oci://registry.onelitefeather.dev/stelaris/stelaris-ui \
+  --version 1.0.0 \
+  --namespace stelaris --create-namespace \
+  --set config.backendUrl=https://api.stelaris.example/v1 \
+  --set config.generatorUrl=https://gen.stelaris.example
+```
+
+The two `--set` values become the Secret the app reads at startup. nginx serves
+that file from disk per request, so changing it later takes effect without a
+rollout. The chart's [README](charts/stelaris-ui/README.md) covers the ingress,
+narrowing the CSP to real backend origins, and what the pod is and is not
+allowed to do.
+
 ## Wiki
 
 You can find the Wiki under the following [Link](https://gitlab.onelitefeather.dev/dungeon/frontend/stelaris-ui/-/wikis/pages)

--- a/charts/stelaris-ui/.helmignore
+++ b/charts/stelaris-ui/.helmignore
@@ -1,0 +1,5 @@
+.DS_Store
+.git/
+.gitignore
+*.tgz
+ci/

--- a/charts/stelaris-ui/Chart.yaml
+++ b/charts/stelaris-ui/Chart.yaml
@@ -7,8 +7,8 @@ type: application
 # and the app version move together: the chart only ever describes the image
 # built from the same commit, so a separate chart version would be a second
 # number to reason about with nothing extra to say.
-version: 1.0.0 # x-release-please-version
-appVersion: "1.0.0" # x-release-please-version
+version: 1.0.0  # x-release-please-version
+appVersion: "1.0.0"  # x-release-please-version
 
 home: https://github.com/OneLiteFeatherNET/stelaris
 sources:

--- a/charts/stelaris-ui/Chart.yaml
+++ b/charts/stelaris-ui/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v2
+name: stelaris-ui
+description: The Stelaris UI web application, served by a hardened, unprivileged nginx
+type: application
+
+# Both lines are kept current by Release Please, which is why the chart version
+# and the app version move together: the chart only ever describes the image
+# built from the same commit, so a separate chart version would be a second
+# number to reason about with nothing extra to say.
+version: 1.0.0 # x-release-please-version
+appVersion: "1.0.0" # x-release-please-version
+
+home: https://github.com/OneLiteFeatherNET/stelaris
+sources:
+  - https://github.com/OneLiteFeatherNET/stelaris
+maintainers:
+  - name: OneLiteFeatherNET
+    email: contact@onelitefeather.net
+    url: https://onelitefeather.net
+keywords:
+  - stelaris
+  - flutter
+  - minecraft
+annotations:
+  artifacthub.io/license: GPL-3.0

--- a/charts/stelaris-ui/README.md
+++ b/charts/stelaris-ui/README.md
@@ -130,6 +130,28 @@ ingress:
 `networkPolicy.ingressFrom` and denies all egress — the browser talks to the
 backend, not this pod, so it has no egress worth allowing.
 
+## Checking a change to the chart
+
+Template assertions live next to the chart and run without a cluster:
+
+```sh
+helm plugin install https://github.com/helm-unittest/helm-unittest --verify=false
+helm unittest charts/stelaris-ui
+```
+
+They assert on the rendered manifests directly - that the pod really is
+unprivileged and read-only, that the runtime config is mounted as a directory
+and not with `subPath`, that a Secret change carries no checksum annotation
+while an nginx change does. Those are the properties this chart exists to get
+right, and rendering and grepping never checked them reliably.
+
+`ct lint` covers the rest, linting the chart once per file in
+[`ci/`](ci) - a minimal deployment and one with everything enabled:
+
+```sh
+ct lint --config ct.yaml
+```
+
 ## Verifying a release
 
 ```sh
@@ -138,7 +160,8 @@ helm test stelaris-ui --namespace stelaris
 
 The test pod asserts that `/healthz` answers, the app shell is served, a deep
 link reaches the shell rather than a 404, and `/config.json` returns the
-document this release put there.
+document this release put there. It is the only place the running container's
+behaviour is checked, so it is worth running after an install.
 
 ## Values
 

--- a/charts/stelaris-ui/README.md
+++ b/charts/stelaris-ui/README.md
@@ -2,11 +2,12 @@
 
 The Stelaris UI web application, served by a hardened, unprivileged nginx.
 
-The chart is published as an OCI artifact to the OneLiteFeather Harbor, next to
-the image it deploys:
+The chart is published as an OCI artifact into the OneLiteFeather Harbor, under
+`onelitefeather/charts/`, next to the `onelitefeather/stelaris` image it
+deploys:
 
 ```sh
-helm install stelaris-ui oci://registry.onelitefeather.dev/stelaris/stelaris-ui \
+helm install stelaris-ui oci://harbor.onelitefeather.dev/onelitefeather/charts/stelaris-ui \
   --version 1.0.0 \
   --namespace stelaris --create-namespace \
   --set config.backendUrl=https://api.stelaris.example/v1 \

--- a/charts/stelaris-ui/README.md
+++ b/charts/stelaris-ui/README.md
@@ -1,0 +1,158 @@
+# stelaris-ui
+
+The Stelaris UI web application, served by a hardened, unprivileged nginx.
+
+The chart is published as an OCI artifact to the OneLiteFeather Harbor, next to
+the image it deploys:
+
+```sh
+helm install stelaris-ui oci://registry.onelitefeather.dev/stelaris/stelaris-ui \
+  --version 1.0.0 \
+  --namespace stelaris --create-namespace \
+  --set config.backendUrl=https://api.stelaris.example/v1 \
+  --set config.generatorUrl=https://gen.stelaris.example
+```
+
+The chart version and the app version move together: a chart release only ever
+describes the image built from the same commit, so `image.tag` defaults to the
+chart's `appVersion` and normally needs no value at all.
+
+## What it deploys
+
+| Resource | When |
+| --- | --- |
+| `Deployment` | always — 2 replicas, rolling update with `maxUnavailable: 0` |
+| `Service` | always — ClusterIP on port 80 → container 8080 |
+| `Secret` | unless `config.existingSecret` is set |
+| `ServiceAccount` | unless `serviceAccount.create=false` — no API token mounted |
+| `PodDisruptionBudget` | unless disabled |
+| `ConfigMap` | only if an `nginx.*` override is set |
+| `Ingress` | `ingress.enabled=true` |
+| `HorizontalPodAutoscaler` | `autoscaling.enabled=true` |
+| `NetworkPolicy` | `networkPolicy.enabled=true` |
+
+## Configuration reaches the app at runtime
+
+The image is built once and promoted from staging to production, so the backend
+it talks to is not compiled into the bundle. The app fetches `config.json` when
+it starts; this chart puts that document in a Secret and mounts it over the
+server's runtime directory:
+
+```yaml
+config:
+  backendUrl: https://api.stelaris.example/v1
+  generatorUrl: https://gen.stelaris.example
+```
+
+nginx serves that file from disk on every request, so **changing the Secret
+takes effect without a rollout** — a browser reload is enough. That is why the
+Deployment carries no checksum annotation for it.
+
+A field left empty is left out of the document, and the app falls back to the
+value compiled into the bundle for that field alone. A missing, unreachable or
+malformed configuration is never fatal: the app starts on its defaults rather
+than not starting.
+
+To manage the Secret outside this chart — sealed-secrets, external-secrets, or
+by hand:
+
+```yaml
+config:
+  existingSecret: stelaris-ui-config
+  secretKey: config.json   # the key holding the whole document
+```
+
+## Tightening the Content-Security-Policy
+
+The image ships `connect-src 'self' https:`, because an image that is built once
+and promoted cannot know which hosts it will be allowed to talk to. Naming them
+turns the policy from "any HTTPS host" into "these hosts":
+
+```yaml
+nginx:
+  contentSecurityPolicy: >-
+    default-src 'self'; base-uri 'self'; object-src 'none';
+    frame-ancestors 'none'; form-action 'none';
+    script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval';
+    style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:;
+    font-src 'self' data:; media-src 'self' data: blob:;
+    worker-src 'self' blob:; child-src 'self' blob:; manifest-src 'self';
+    connect-src 'self' https://api.stelaris.example https://gen.stelaris.example
+```
+
+`'unsafe-inline'` and `'unsafe-eval'` are not optional — Flutter's loader
+bootstraps from an inline script and compiles Wasm at runtime. Dropping them
+gives a blank page. The reasoning is in
+[`docs/docker-image.md`](../../docs/docker-image.md).
+
+This replaces one file inside the image, so a change to it **does** roll the
+pods: nginx reads its configuration only at startup.
+
+## Replacing the server block
+
+`nginx.serverConfig` replaces `/etc/nginx/conf.d/default.conf` wholesale. It
+exists for the one thing the image cannot decide for itself — a dual-stack
+cluster that needs an IPv6 listener:
+
+```yaml
+nginx:
+  serverConfig: |
+    # copy of docker/nginx/conf.d/default.conf, plus:
+    listen [::]:8080;
+```
+
+Copy the file from the repository and edit it; anything else and the app stops
+being served. A mistake here fails the readiness probe, so the rollout stops
+rather than taking the running pods with it.
+
+## Security posture
+
+The pod runs as uid 101 with a read-only root filesystem, no capabilities, no
+privilege escalation and `seccompProfile: RuntimeDefault`. `/tmp` is a 16 MiB
+in-memory `emptyDir` and is the only writable path in the container — nginx's
+pid file and all of its temp paths live there.
+
+`automountServiceAccountToken: false`: the app never calls the Kubernetes API.
+
+`Strict-Transport-Security` is **not** sent by the container, deliberately — TLS
+terminates at the ingress, which is the only place that knows whether the
+deployment is reachable over HTTPS and on which hostnames. Set it there:
+
+```yaml
+ingress:
+  annotations:
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "Strict-Transport-Security: max-age=31536000; includeSubDomains";
+```
+
+`networkPolicy.enabled=true` restricts ingress to the pods named in
+`networkPolicy.ingressFrom` and denies all egress — the browser talks to the
+backend, not this pod, so it has no egress worth allowing.
+
+## Verifying a release
+
+```sh
+helm test stelaris-ui --namespace stelaris
+```
+
+The test pod asserts that `/healthz` answers, the app shell is served, a deep
+link reaches the shell rather than a 404, and `/config.json` returns the
+document this release put there.
+
+## Values
+
+The annotated defaults are in [`values.yaml`](values.yaml). The ones worth
+knowing about:
+
+| Key | Default | |
+| --- | --- | --- |
+| `config.backendUrl` | `""` | Without it the app has nothing to talk to |
+| `config.generatorUrl` | `""` | |
+| `config.existingSecret` | `""` | Manage the Secret elsewhere |
+| `nginx.contentSecurityPolicy` | `""` | Narrow `connect-src` to real origins |
+| `nginx.serverConfig` | `""` | Replace the server block entirely |
+| `image.tag` | `""` | Empty means the chart's `appVersion` |
+| `replicaCount` | `2` | Ignored when `autoscaling.enabled` |
+| `resources` | 20m CPU / 64Mi | Guaranteed QoS, no CPU limit |
+| `ingress.enabled` | `false` | |
+| `networkPolicy.enabled` | `false` | |

--- a/charts/stelaris-ui/ci/default-values.yaml
+++ b/charts/stelaris-ui/ci/default-values.yaml
@@ -1,0 +1,4 @@
+# What a minimal real deployment sets: the two URLs the app needs, nothing else.
+config:
+  backendUrl: https://api.stelaris.example/v1
+  generatorUrl: https://gen.stelaris.example

--- a/charts/stelaris-ui/ci/full-values.yaml
+++ b/charts/stelaris-ui/ci/full-values.yaml
@@ -1,0 +1,56 @@
+# Everything optional turned on at once, so the templates that only exist under
+# a condition are rendered by the linter too.
+config:
+  backendUrl: https://api.stelaris.example/v1
+  generatorUrl: https://gen.stelaris.example
+
+nginx:
+  contentSecurityPolicy: >-
+    default-src 'self'; base-uri 'self'; object-src 'none';
+    frame-ancestors 'none'; form-action 'none';
+    script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval';
+    style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:;
+    font-src 'self' data:; media-src 'self' data: blob:;
+    worker-src 'self' blob:; child-src 'self' blob:; manifest-src 'self';
+    connect-src 'self' https://api.stelaris.example https://gen.stelaris.example
+  serverConfig: |
+    server {
+        listen      8080;
+        listen      [::]:8080;
+        server_name _;
+        root  /usr/share/nginx/html;
+        index index.html;
+        location = /healthz {
+            access_log off;
+            default_type text/plain;
+            return 200 "ok\n";
+        }
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+    }
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+  hosts:
+    - host: stelaris.example
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: stelaris-ui-tls
+      hosts:
+        - stelaris.example
+
+autoscaling:
+  enabled: true
+
+networkPolicy:
+  enabled: true
+  ingressFrom:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: ingress-nginx

--- a/charts/stelaris-ui/templates/NOTES.txt
+++ b/charts/stelaris-ui/templates/NOTES.txt
@@ -1,0 +1,47 @@
+{{ .Chart.Name }} {{ .Chart.Version }} is installed as {{ .Release.Name }} in {{ .Release.Namespace }}.
+
+Image: {{ include "stelaris-ui.image" . }}
+
+{{- if .Values.ingress.enabled }}
+
+Reachable at:
+{{- range .Values.ingress.hosts }}
+{{- $scheme := "http" }}
+{{- range $.Values.ingress.tls }}{{ if has (index $.Values.ingress.hosts 0).host .hosts }}{{ $scheme = "https" }}{{ end }}{{ end }}
+{{- range .paths }}
+  {{ $scheme }}://{{ (index $.Values.ingress.hosts 0).host }}{{ .path }}
+{{- end }}
+{{- end }}
+{{- else }}
+
+No Ingress is enabled. To look at it locally:
+
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "stelaris-ui.fullname" . }} 8080:{{ .Values.service.port }}
+
+then open http://127.0.0.1:8080
+{{- end }}
+
+{{- if and (not .Values.config.existingSecret) (not .Values.config.backendUrl) }}
+
+WARNING: config.backendUrl is not set.
+
+The app will start, but it has nothing to talk to: it falls back to the URLs
+compiled into the bundle, which are empty. Set it and upgrade:
+
+  helm upgrade {{ .Release.Name }} … --set config.backendUrl=https://api.example/v1
+
+nginx serves that file from disk per request, so this takes effect without a
+rollout - a browser reload is enough.
+{{- end }}
+
+{{- if not .Values.nginx.contentSecurityPolicy }}
+
+Note: the Content-Security-Policy allows `connect-src 'self' https:`, which is
+the image default - it is built once and promoted, so it cannot know its
+backends. Narrow it to the actual origins with `nginx.contentSecurityPolicy`;
+see the chart README.
+{{- end }}
+
+Check the release:
+
+  helm test {{ .Release.Name }} --namespace {{ .Release.Namespace }}

--- a/charts/stelaris-ui/templates/_helpers.tpl
+++ b/charts/stelaris-ui/templates/_helpers.tpl
@@ -1,0 +1,80 @@
+{{/*
+Chart name, overridable.
+*/}}
+{{- define "stelaris-ui.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Fully qualified app name. Truncated at 63 characters, because some Kubernetes
+name fields are limited to that.
+*/}}
+{{- define "stelaris-ui.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "stelaris-ui.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "stelaris-ui.labels" -}}
+helm.sh/chart: {{ include "stelaris-ui.chart" . }}
+{{ include "stelaris-ui.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: stelaris
+{{- end }}
+
+{{- define "stelaris-ui.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "stelaris-ui.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "stelaris-ui.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "stelaris-ui.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+The image reference. An empty tag means the chart's appVersion, so a release of
+the chart always describes the image built from the same commit.
+*/}}
+{{- define "stelaris-ui.image" -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag -}}
+{{- if .Values.image.registry -}}
+{{- printf "%s/%s:%s" .Values.image.registry .Values.image.repository $tag -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+The Secret holding config.json - the one this chart creates, or an existing one.
+*/}}
+{{- define "stelaris-ui.configSecretName" -}}
+{{- default (printf "%s-config" (include "stelaris-ui.fullname" .)) .Values.config.existingSecret }}
+{{- end }}
+
+{{/*
+Whether anything overrides the nginx configuration in the image. Used to decide
+whether the ConfigMap and its mounts exist at all.
+*/}}
+{{- define "stelaris-ui.hasNginxOverrides" -}}
+{{- if or .Values.nginx.contentSecurityPolicy .Values.nginx.serverConfig -}}
+true
+{{- end -}}
+{{- end }}

--- a/charts/stelaris-ui/templates/configmap-nginx.yaml
+++ b/charts/stelaris-ui/templates/configmap-nginx.yaml
@@ -1,0 +1,19 @@
+{{- if include "stelaris-ui.hasNginxOverrides" . }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "stelaris-ui.fullname" . }}-nginx
+  labels:
+    {{- include "stelaris-ui.labels" . | nindent 4 }}
+data:
+  {{- if .Values.nginx.contentSecurityPolicy }}
+  # Replaces the file the image ships. Everything else in
+  # security-headers.conf, which includes this one, stays as built.
+  content-security-policy.conf: |
+    add_header Content-Security-Policy {{ .Values.nginx.contentSecurityPolicy | trim | quote }} always;
+  {{- end }}
+  {{- if .Values.nginx.serverConfig }}
+  default.conf: |
+    {{- .Values.nginx.serverConfig | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/stelaris-ui/templates/deployment.yaml
+++ b/charts/stelaris-ui/templates/deployment.yaml
@@ -1,0 +1,137 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "stelaris-ui.fullname" . }}
+  labels:
+    {{- include "stelaris-ui.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "stelaris-ui.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      # Bring the new pod up before taking an old one down: the workload is
+      # stateless and cheap, so there is no reason for a rollout to reduce
+      # capacity.
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        {{- include "stelaris-ui.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        {{- if include "stelaris-ui.hasNginxOverrides" . }}
+        # nginx reads its configuration once, at startup, so a change to it has
+        # to roll the pods. config.json deliberately has no checksum here: nginx
+        # serves that file from disk per request, so the kubelet updating it in
+        # place is enough and a rollout would be pure churn.
+        checksum/nginx-config: {{ include (print $.Template.BasePath "/configmap-nginx.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "stelaris-ui.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: {{ include "stelaris-ui.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.targetPort }}
+              protocol: TCP
+          {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            # The container's only writable path. nginx puts its pid file and
+            # every temp path here, which is what lets the root filesystem stay
+            # read-only.
+            - name: tmp
+              mountPath: /tmp
+            # Mounted as a directory, not with subPath, so the kubelet keeps the
+            # file current after a Secret update without restarting the pod.
+            - name: runtime-config
+              mountPath: /etc/nginx/runtime
+              readOnly: true
+            {{- if .Values.nginx.contentSecurityPolicy }}
+            - name: nginx-config
+              mountPath: /etc/nginx/snippets/content-security-policy.conf
+              subPath: content-security-policy.conf
+              readOnly: true
+            {{- end }}
+            {{- if .Values.nginx.serverConfig }}
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: default.conf
+              readOnly: true
+            {{- end }}
+      volumes:
+        - name: tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: {{ .Values.tmpVolume.sizeLimit }}
+        - name: runtime-config
+          secret:
+            secretName: {{ include "stelaris-ui.configSecretName" . }}
+            items:
+              # Projected under the name nginx serves it as, whatever the key is
+              # called in the Secret.
+              - key: {{ .Values.config.secretKey }}
+                path: config.json
+        {{- if include "stelaris-ui.hasNginxOverrides" . }}
+        - name: nginx-config
+          configMap:
+            name: {{ include "stelaris-ui.fullname" . }}-nginx
+        {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- range . }}
+        - maxSkew: {{ .maxSkew }}
+          topologyKey: {{ .topologyKey }}
+          whenUnsatisfiable: {{ .whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              {{- include "stelaris-ui.selectorLabels" $ | nindent 14 }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/stelaris-ui/templates/hpa.yaml
+++ b/charts/stelaris-ui/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "stelaris-ui.fullname" . }}
+  labels:
+    {{- include "stelaris-ui.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "stelaris-ui.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- with .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+    {{- end }}
+    {{- with .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+    {{- end }}
+{{- end }}

--- a/charts/stelaris-ui/templates/ingress.yaml
+++ b/charts/stelaris-ui/templates/ingress.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.ingress.enabled }}
+{{- $fullName := include "stelaris-ui.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "stelaris-ui.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/stelaris-ui/templates/networkpolicy.yaml
+++ b/charts/stelaris-ui/templates/networkpolicy.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "stelaris-ui.fullname" . }}
+  labels:
+    {{- include "stelaris-ui.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "stelaris-ui.selectorLabels" . | nindent 6 }}
+  # Ingress only. The browser talks to the backend directly, so this pod has no
+  # egress worth allowing - and naming no egress rule at all under this policy
+  # type would deny it, which is exactly right.
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        {{- toYaml .Values.networkPolicy.ingressFrom | nindent 8 }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.service.targetPort }}
+{{- end }}

--- a/charts/stelaris-ui/templates/pdb.yaml
+++ b/charts/stelaris-ui/templates/pdb.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "stelaris-ui.fullname" . }}
+  labels:
+    {{- include "stelaris-ui.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "stelaris-ui.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/stelaris-ui/templates/secret.yaml
+++ b/charts/stelaris-ui/templates/secret.yaml
@@ -1,0 +1,25 @@
+{{- if not .Values.config.existingSecret }}
+{{- /*
+  A Secret rather than a ConfigMap, even though these are URLs and not
+  credentials: it is the same document the browser will be handed, and a
+  deployment that later needs to put something sensitive in it should not have
+  to move the whole mechanism to get there.
+
+  Fields left empty are omitted from the document entirely, because the app
+  falls back to its compiled-in default per field. A key with an empty string
+  would say nothing different and would hide that nothing was configured.
+*/}}
+{{- $config := dict -}}
+{{- with .Values.config.backendUrl }}{{- $_ := set $config "backendUrl" . -}}{{- end -}}
+{{- with .Values.config.generatorUrl }}{{- $_ := set $config "generatorUrl" . -}}{{- end -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "stelaris-ui.fullname" . }}-config
+  labels:
+    {{- include "stelaris-ui.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ .Values.config.secretKey }}: |-
+{{ $config | toPrettyJson | indent 4 }}
+{{- end }}

--- a/charts/stelaris-ui/templates/service.yaml
+++ b/charts/stelaris-ui/templates/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "stelaris-ui.fullname" . }}
+  labels:
+    {{- include "stelaris-ui.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      # By name, not number: the container's port is unprivileged and the
+      # Service's is the familiar one, and the two should be free to differ.
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "stelaris-ui.selectorLabels" . | nindent 4 }}

--- a/charts/stelaris-ui/templates/serviceaccount.yaml
+++ b/charts/stelaris-ui/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "stelaris-ui.serviceAccountName" . }}
+  labels:
+    {{- include "stelaris-ui.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+# The app never calls the Kubernetes API. Its own account exists so the pod is
+# not running as `default`, not so it can do anything with it.
+automountServiceAccountToken: false
+{{- end }}

--- a/charts/stelaris-ui/templates/tests/test-connection.yaml
+++ b/charts/stelaris-ui/templates/tests/test-connection.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "stelaris-ui.fullname" . }}-test"
+  labels:
+    {{- include "stelaris-ui.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  automountServiceAccountToken: false
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65534
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: check
+      image: curlimages/curl:8.20.1
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL
+      args:
+        - /bin/sh
+        - -ec
+        - |
+          host="{{ include "stelaris-ui.fullname" . }}:{{ .Values.service.port }}"
+
+          # The probe endpoint, which is what tells us the pod is up at all.
+          curl -fsS "http://$host/healthz"
+
+          # The app shell, which is what tells us the bundle actually shipped.
+          curl -fsS -o /dev/null "http://$host/"
+
+          # The runtime configuration - the one piece that comes from this
+          # release rather than from the image, so it is the one worth
+          # asserting on.
+          curl -fsS "http://$host/config.json" | grep -q '{'
+
+          # A deep link has to reach the app shell, not a 404, or every
+          # bookmarked route in the app is broken.
+          test "$(curl -s -o /dev/null -w '%{http_code}' "http://$host/items/deep/link")" = "200"
+
+          echo "ok"

--- a/charts/stelaris-ui/tests/config_test.yaml
+++ b/charts/stelaris-ui/tests/config_test.yaml
@@ -1,0 +1,94 @@
+suite: runtime configuration
+templates:
+  - secret.yaml
+  - configmap-nginx.yaml
+  - deployment.yaml
+tests:
+  - it: renders an empty document when nothing is configured
+    # The app falls back to its compiled-in defaults per field, so an empty
+    # object is the honest thing to serve. A key with an empty string would
+    # look configured and behave the same.
+    template: secret.yaml
+    asserts:
+      - equal:
+          path: stringData["config.json"]
+          value: "{}"
+
+  - it: leaves out a field that was not set
+    template: secret.yaml
+    set:
+      config.backendUrl: https://api.example/v1
+    asserts:
+      - matchRegex:
+          path: stringData["config.json"]
+          pattern: '"backendUrl": "https://api\.example/v1"'
+      - notMatchRegex:
+          path: stringData["config.json"]
+          pattern: 'generatorUrl'
+
+  - it: renders both URLs when both are set
+    template: secret.yaml
+    set:
+      config.backendUrl: https://api.example/v1
+      config.generatorUrl: https://gen.example
+    asserts:
+      - matchRegex:
+          path: stringData["config.json"]
+          pattern: '"generatorUrl": "https://gen\.example"'
+
+  - it: creates no Secret when an existing one is named
+    template: secret.yaml
+    set:
+      config.existingSecret: managed-elsewhere
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: mounts the existing Secret instead
+    template: deployment.yaml
+    set:
+      config.existingSecret: managed-elsewhere
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: runtime-config
+            secret:
+              secretName: managed-elsewhere
+              items:
+                - key: config.json
+                  path: config.json
+
+  - it: projects a differently named key as config.json
+    # nginx serves whatever is at that path, so the key in the Secret is free
+    # to be named for whatever manages it.
+    template: deployment.yaml
+    set:
+      config.existingSecret: managed-elsewhere
+      config.secretKey: stelaris-ui.json
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: runtime-config
+            secret:
+              secretName: managed-elsewhere
+              items:
+                - key: stelaris-ui.json
+                  path: config.json
+
+  - it: creates no nginx ConfigMap unless something overrides the image
+    template: configmap-nginx.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: wraps a policy in the add_header directive nginx expects
+    template: configmap-nginx.yaml
+    set:
+      nginx.contentSecurityPolicy: "default-src 'self'; connect-src 'self' https://api.example"
+    asserts:
+      - equal:
+          path: data["content-security-policy.conf"]
+          value: |
+            add_header Content-Security-Policy "default-src 'self'; connect-src 'self' https://api.example" always;

--- a/charts/stelaris-ui/tests/deployment_test.yaml
+++ b/charts/stelaris-ui/tests/deployment_test.yaml
@@ -1,0 +1,129 @@
+suite: deployment
+# configmap-nginx.yaml is listed because the Deployment's checksum annotation
+# includes it; without it in scope the template cannot render at all.
+templates:
+  - deployment.yaml
+  - configmap-nginx.yaml
+tests:
+  - it: runs unprivileged, read-only and without capabilities
+    template: deployment.yaml
+    # The image was built to run this way. If a value ever loosens one of
+    # these, the pod would start with more privilege than it needs and nothing
+    # else would notice.
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 101
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          value: [ALL]
+
+  - it: gives the container /tmp in memory and nothing else to write to
+    template: deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: tmp
+            emptyDir:
+              medium: Memory
+              sizeLimit: 16Mi
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: tmp
+            mountPath: /tmp
+
+  - it: mounts the runtime config as a directory, not with subPath
+    template: deployment.yaml
+    # subPath would freeze the file at the version it had when the pod started,
+    # which is what makes a Secret update need a rollout. As a directory the
+    # kubelet keeps it current, and nginx reads it per request.
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: runtime-config
+            mountPath: /etc/nginx/runtime
+            readOnly: true
+      - notExists:
+          path: spec.template.spec.containers[0].volumeMounts[1].subPath
+
+  - it: does not roll the pods when only the runtime config changes
+    template: deployment.yaml
+    # No checksum annotation for the Secret, deliberately - see above.
+    set:
+      config.backendUrl: https://api.example/v1
+    asserts:
+      - notExists:
+          path: spec.template.metadata.annotations["checksum/nginx-config"]
+
+  - it: rolls the pods when the nginx configuration changes
+    template: deployment.yaml
+    # The opposite case: nginx reads its own configuration only at startup.
+    set:
+      nginx.contentSecurityPolicy: "default-src 'self'"
+    asserts:
+      - exists:
+          path: spec.template.metadata.annotations["checksum/nginx-config"]
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: nginx-config
+            mountPath: /etc/nginx/snippets/content-security-policy.conf
+            subPath: content-security-policy.conf
+            readOnly: true
+
+  - it: never mounts a service account token
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+
+  - it: serves on the unprivileged port the image listens on
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 8080
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /healthz
+
+  - it: keeps capacity during a rollout
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 0
+
+  - it: defaults the image tag to the chart's appVersion
+    template: deployment.yaml
+    chart:
+      appVersion: 9.9.9
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: harbor.onelitefeather.dev/onelitefeather/stelaris:9.9.9
+
+  - it: lets a branch build override the tag
+    template: deployment.yaml
+    set:
+      image.tag: 1.0.0-something
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: harbor.onelitefeather.dev/onelitefeather/stelaris:1.0.0-something

--- a/charts/stelaris-ui/values.yaml
+++ b/charts/stelaris-ui/values.yaml
@@ -9,8 +9,8 @@ replicaCount: 2
 image:
   # Registry host. Empty means the Harbor host the image is published to; set
   # this to deploy from a mirror or a local registry.
-  registry: registry.onelitefeather.dev
-  repository: stelaris/stelaris-ui
+  registry: harbor.onelitefeather.dev
+  repository: onelitefeather/stelaris
   # Empty means the chart's appVersion, so the chart and the image it describes
   # are released together. Override to run a branch build.
   tag: ""

--- a/charts/stelaris-ui/values.yaml
+++ b/charts/stelaris-ui/values.yaml
@@ -1,0 +1,205 @@
+# Default values for stelaris-ui.
+#
+# The defaults are meant to be deployable as they stand, apart from the two
+# backend URLs under `config` - the app starts without them but has nothing to
+# talk to.
+
+replicaCount: 2
+
+image:
+  # Registry host. Empty means the Harbor host the image is published to; set
+  # this to deploy from a mirror or a local registry.
+  registry: registry.onelitefeather.dev
+  repository: stelaris/stelaris-ui
+  # Empty means the chart's appVersion, so the chart and the image it describes
+  # are released together. Override to run a branch build.
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+# Runtime configuration the app fetches as /config.json. It reaches the
+# container as a Secret mounted over the server's runtime directory - nginx
+# reads the file per request, so changing the Secret takes effect without a
+# rollout.
+config:
+  # Base URL of the Stelaris backend, e.g. https://api.stelaris.example/v1.
+  backendUrl: ""
+  # Base URL of the code generator service.
+  generatorUrl: ""
+
+  # Use a Secret managed outside this chart instead of the one it creates.
+  # It has to hold the whole document under `secretKey`.
+  existingSecret: ""
+  secretKey: config.json
+
+# Overrides for the nginx configuration baked into the image. Each one that is
+# set is rendered into a ConfigMap and mounted over the corresponding file; a
+# change to either rolls the Deployment, because nginx reads its configuration
+# only at startup.
+nginx:
+  # The Content-Security-Policy header, without the directive name.
+  #
+  # The image ships `connect-src 'self' https:`, because an image that is built
+  # once and promoted cannot know its backends. Set this to name them, which is
+  # what turns the policy from "any HTTPS host" into "these hosts":
+  #
+  #   contentSecurityPolicy: >-
+  #     default-src 'self'; base-uri 'self'; object-src 'none';
+  #     frame-ancestors 'none'; form-action 'none';
+  #     script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval';
+  #     style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:;
+  #     font-src 'self' data:; media-src 'self' data: blob:;
+  #     worker-src 'self' blob:; child-src 'self' blob:; manifest-src 'self';
+  #     connect-src 'self' https://api.stelaris.example
+  #
+  # `unsafe-inline` and `unsafe-eval` are not optional - Flutter's loader
+  # bootstraps from an inline script and compiles Wasm at runtime. See
+  # docs/docker-image.md.
+  contentSecurityPolicy: ""
+
+  # The whole server block, replacing /etc/nginx/conf.d/default.conf. Only
+  # needed for something the image cannot decide for itself - a dual-stack
+  # cluster adding `listen [::]:8080;`, for one. Copy
+  # docker/nginx/conf.d/default.conf and edit it; a mistake here takes the pods
+  # down, so the readiness probe is what catches it.
+  serverConfig: ""
+
+service:
+  type: ClusterIP
+  port: 80
+  # The container listens unprivileged; only the Service port is the familiar 80.
+  targetPort: 8080
+  annotations: {}
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  #   TLS terminates here, so this is where HSTS belongs - the image
+  #   deliberately does not send it, because only the ingress knows whether the
+  #   deployment is reachable over HTTPS.
+  hosts: []
+  #  - host: stelaris.example
+  #    paths:
+  #      - path: /
+  #        pathType: Prefix
+  tls: []
+  #  - secretName: stelaris-ui-tls
+  #    hosts:
+  #      - stelaris.example
+
+# Serving static files out of the page cache. The memory limit equals the
+# request on purpose: nginx's working set is flat and predictable, so a
+# Guaranteed pod is the right QoS class. No CPU limit - throttling a request
+# path that is mostly sendfile() only adds latency.
+resources:
+  requests:
+    cpu: 20m
+    memory: 64Mi
+  limits:
+    memory: 64Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 6
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: ""
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+  maxUnavailable: ""
+
+# Deny-by-default egress is deliberately not part of this: the browser talks to
+# the backend, not the pod, so this workload has no egress worth allowing.
+# Ingress is restricted to whatever fronts it.
+networkPolicy:
+  enabled: false
+  # Selects the pods allowed to reach this one - the ingress controller.
+  # An empty list allows any pod in any namespace, which is the same as not
+  # enabling the policy at all.
+  ingressFrom: []
+  #  - namespaceSelector:
+  #      matchLabels:
+  #        kubernetes.io/metadata.name: ingress-nginx
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+# The image runs as uid 101 with a read-only root filesystem and needs no
+# capabilities. Changing any of this makes the pod fail to start rather than
+# quietly running with more privilege than it needs.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 101
+  runAsGroup: 101
+  fsGroup: 101
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  privileged: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+# /tmp is the container's only writable path: nginx's pid file and all of its
+# temp paths live there. In memory, because none of it should ever reach a disk
+# and the volume is measured in kilobytes.
+tmpVolume:
+  sizeLimit: 16Mi
+
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  periodSeconds: 10
+  timeoutSeconds: 2
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  periodSeconds: 5
+  timeoutSeconds: 2
+  failureThreshold: 2
+
+startupProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  periodSeconds: 2
+  timeoutSeconds: 2
+  # nginx binds in well under a second; this only has to cover a slow node.
+  failureThreshold: 15
+
+# Spread replicas over nodes, but schedule anyway when that is not possible -
+# a single-node cluster should still get a running deployment.
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels: {} # filled in by the template
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+podAnnotations: {}
+podLabels: {}
+
+# The app never talks to the Kubernetes API, so it has no use for a token.
+automountServiceAccountToken: false
+
+# Static files, so a slow client draining is the only reason to wait.
+terminationGracePeriodSeconds: 30

--- a/charts/stelaris-ui/values.yaml
+++ b/charts/stelaris-ui/values.yaml
@@ -189,7 +189,7 @@ topologySpreadConstraints:
     topologyKey: kubernetes.io/hostname
     whenUnsatisfiable: ScheduleAnyway
     labelSelector:
-      matchLabels: {} # filled in by the template
+      matchLabels: {}  # filled in by the template
 
 nodeSelector: {}
 tolerations: []

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,12 @@
+# chart-testing. `ct lint` picks up every charts/*/ci/*-values.yaml and lints
+# the chart once per file, which is what replaced rendering those shapes by
+# hand in the workflow.
+chart-dirs:
+  - charts
+target-branch: develop
+# The chart carries no maintainers list beyond the org itself, and requiring
+# every entry to resolve to a GitHub user would fail on a team address.
+validate-maintainers: false
+# Release Please owns version and appVersion through extra-files, so a chart
+# change is not supposed to bump them by hand - and ct would insist on it.
+check-version-increment: false

--- a/docs/docker-image.md
+++ b/docs/docker-image.md
@@ -129,7 +129,10 @@ containers:
         mountPath: /tmp
 ```
 
-(The Helm chart that packages this is a separate change.)
+That, and everything else the deployment needs, is packaged in
+[`charts/stelaris-ui`](../charts/stelaris-ui) — the snippet above is what the
+chart renders, shown here so the image's side of the contract is readable on its
+own.
 
 Behaviour worth knowing:
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,10 @@
   "packages": {
     ".": {
       "package-name": "stelaris",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        "charts/stelaris-ui/Chart.yaml"
+      ]
     }
   },
   "bootstrap-sha": "15d48d2a3949104cedaf00b3d7179e4c05754fd9"

--- a/renovate.json
+++ b/renovate.json
@@ -51,6 +51,18 @@
         "image: (?<depName>[a-z0-9./-]+):(?<currentValue>[^\\s@\"']+)"
       ],
       "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "description": "The helm-unittest plugin version pinned in the workflows",
+      "managerFilePatterns": [
+        "/^\\.github/workflows/[^/]+\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "UNITTEST_VERSION: (?<currentValue>\\S+)"
+      ],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "helm-unittest/helm-unittest"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -40,6 +40,17 @@
       "datasourceTemplate": "flutter-version",
       "depNameTemplate": "flutter",
       "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Container images referenced from the Helm chart's templates",
+      "managerFilePatterns": [
+        "/^charts/[^/]+/templates/.+\\.yaml$/"
+      ],
+      "matchStrings": [
+        "image: (?<depName>[a-z0-9./-]+):(?<currentValue>[^\\s@\"']+)"
+      ],
+      "datasourceTemplate": "docker"
     }
   ]
 }


### PR DESCRIPTION
## Proposed changes

A Helm chart that deploys the UI image to Kubernetes, published as an OCI
artifact into `harbor.onelitefeather.dev/onelitefeather/charts/`, next to the
`onelitefeather/stelaris` image it deploys. That project is where `otis` and
`sturnus` already live, and the `<project>/charts/<chart>` layout is the one
Apus established - so a Flux `OCIRepository` pointing at this looks like every
other one in the cluster repository.

> #124 has merged, and this is rebased onto `develop`, so the diff is the chart
> and nothing else.

```sh
helm install stelaris-ui oci://harbor.onelitefeather.dev/onelitefeather/charts/stelaris-ui \
  --version 1.0.0 \
  --namespace stelaris --create-namespace \
  --set config.backendUrl=https://api.stelaris.example/v1 \
  --set config.generatorUrl=https://gen.stelaris.example
```

### What it deploys

`Deployment`, `Service`, `Secret`, `ServiceAccount` and `PodDisruptionBudget` by
default; `Ingress`, `HorizontalPodAutoscaler`, `NetworkPolicy` and an nginx
`ConfigMap` when asked for.

The pod runs the way the image was built to run — uid 101, read-only root
filesystem, `drop: [ALL]`, no privilege escalation, `seccompProfile:
RuntimeDefault`, and `automountServiceAccountToken: false`, since the app never
calls the Kubernetes API. Its only writable path is a 16 MiB in-memory
`emptyDir` on `/tmp`, which is where nginx keeps its pid file and every temp
path.

Rollouts are `maxUnavailable: 0` / `maxSurge: 1` — the workload is stateless and
cheap, so a rollout has no reason to reduce capacity. Resources are Guaranteed
QoS (64Mi request = limit) with no CPU limit: throttling a path that is mostly
`sendfile()` only adds latency.

### Configuration, and why it needs no rollout

`config.json` comes from a Secret — the one the chart renders from
`config.backendUrl`/`config.generatorUrl`, or an existing one via
`config.existingSecret`. It is mounted **as a directory, not with `subPath`**,
so the kubelet keeps the file current after a Secret update. nginx serves that
file from disk per request, which means **a configuration change takes effect
without a rollout** — a browser reload is enough. That is why the Deployment
carries no checksum annotation for it.

The nginx overrides are the opposite case: nginx reads its own configuration
only at startup, so those *do* carry a checksum annotation and do roll the pods.

A field left empty is left out of the document entirely, because the app falls
back per field to the value compiled into the bundle. A key with an empty string
would say nothing different and would hide that nothing was configured.

### The two overrides worth having

- **`nginx.contentSecurityPolicy`** narrows `connect-src` from the image's
  `'self' https:` to the actual backend origins. The image is built once and
  promoted between environments, so it cannot know them; the deployment can.
  This replaces one file inside the image, leaving the rest of
  `security-headers.conf` as built.
- **`nginx.serverConfig`** replaces the server block wholesale. It exists for
  the one thing the image cannot decide for itself: an IPv6 listener on a
  dual-stack cluster (see #124 for why that is not the default).

### Versioning

`version` and `appVersion` move together and are kept current by Release Please
through `extra-files`, so a chart release only ever describes the image built
from the same commit — `image.tag` needs no value.

Publishing is chained into the `release-please` run rather than triggered by the
tag, for the reason already documented at the top of that workflow: release-please
tags with `GITHUB_TOKEN`, and such a tag starts no `on: push: tags` workflow.
The publish job asserts that the chart's version matches the release being cut
before pushing — a chart pointing at an image tag nobody built is worse than no
chart.

Charts are published on releases only. To deploy a branch build, point a
released chart at the branch's image tag; that needs no chart of its own.

### How it is checked

`helm unittest` asserts on the rendered manifests as data — 18 assertions
covering the properties this chart exists to get right:

- the container runs read-only, as uid 101, with `drop: [ALL]` and no privilege
  escalation
- `/tmp` is an in-memory `emptyDir` and the only writable path
- the runtime config is mounted **as a directory, not with `subPath`** — the
  difference between a Secret change taking effect and needing a rollout
- a Secret change carries no checksum annotation; an nginx change does
- no ServiceAccount token is mounted
- the image tag defaults to the chart's `appVersion`
- an empty configuration renders `{}` rather than keys with empty strings, and
  `config.existingSecret` suppresses the Secret while still mounting it

These bite: flipping `readOnlyRootFilesystem` to `false` and adding a `subPath`
to the config mount both fail the suite. The render-and-grep version this
replaces would have passed both.

`ct lint` covers the rest, linting the chart once per file in
`charts/stelaris-ui/ci/` — a minimal deployment and one with everything
enabled.

**Not verified: an actual cluster.** #124's branch build does now publish to
`onelitefeather/stelaris`, but no chart has been released yet, and installing
into a live namespace is not something to do from a pull request. I did not
touch the configured `kubectl` contexts.

Worth saying plainly: the cluster reconciles from
`OneLiteFeatherNET/Kubernetes-FLUX`, so deploying this is a pull request there
(a `HelmRelease` plus an `OCIRepository`, next to `otis` and `sturnus`) rather
than a `helm install` from anyone's workstation. The command above is for a
throwaway namespace.

### No shell in the workflows

The chart job started out rendering the templates and grepping the output,
which was a lot of YAML-embedded shell for a check that could not actually tell
whether the pod was unprivileged — only whether the render succeeded. It is
gone: every step is now either an action or a single command, and the
assertions live in `charts/stelaris-ui/tests/` as data.

The publish job no longer verifies that `Chart.yaml` matches the release
either. `helm package` is told `--version` and `--app-version` outright, which
makes the mismatch it was guarding against impossible rather than detected.

### One thing to decide

The chart publish is a repo-local job. Chart publishing is plausibly reusable
across OneLiteFeather repos, in which case it belongs in
`OneLiteFeatherNET/workflows` as a `workflow_call` alongside `docker-publish.yml`
rather than here — but that is a change to another repository, and one consumer
is not yet evidence of a shared need. Worth lifting when a second repo wants it.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

The chart ships a `helm test` pod that asserts `/healthz` answers, the app shell
is served, a deep link reaches the shell rather than a 404, and `/config.json`
returns the document this release put there — the last one being the only part
that comes from the release rather than from the image, and therefore the part
worth asserting on after an install.

`Strict-Transport-Security` is deliberately not sent by the container and not
set by this chart's defaults: TLS terminates at the ingress, which is the only
place that knows whether the deployment is reachable over HTTPS and on which
hostnames. The chart README shows where to set it.
