### PR TITLE
feat(release): version pubspec, the app and the chart from one release

### DIFF
--- a/lib/feature/settings/rows/misc_settings_row.dart
+++ b/lib/feature/settings/rows/misc_settings_row.dart
@@ -40,7 +40,7 @@ class MiscSettingsRow extends StatelessWidget {
                 showLicensePage(
                   context: context,
                   applicationName: appName,
-                  applicationVersion: '0.1.0',
+                  applicationVersion: appVersion,
                 );
               },
               child: Text(context.l10n.settings_misc_license_button),

--- a/lib/util/constants.dart
+++ b/lib/util/constants.dart
@@ -2,6 +2,13 @@ import 'package:material_ui/material_ui.dart';
 
 /// Strings
 const String appName = 'Stelaris';
+
+/// The released version of the app, shown on the license page.
+///
+/// Release Please rewrites this line, so it always matches the version in
+/// pubspec.yaml and the tag the build came from. Do not edit it by hand.
+const String appVersion = '1.0.0'; // x-release-please-version
+
 const String unknownEntry = 'Unknown';
 
 /// EdgeInsets

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: UI for Stelaris
 
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.0+1
+version: 1.0.0 # x-release-please-version
 
 environment:
   sdk: ">=3.13.1 <4.0.0"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,8 @@
       "package-name": "stelaris",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
+        "pubspec.yaml",
+        "lib/util/constants.dart",
         "charts/stelaris-ui/Chart.yaml"
       ]
     }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,9 +8,15 @@
       "package-name": "stelaris",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        "pubspec.yaml",
+        {
+          "type": "generic",
+          "path": "pubspec.yaml"
+        },
         "lib/util/constants.dart",
-        "charts/stelaris-ui/Chart.yaml"
+        {
+          "type": "generic",
+          "path": "charts/stelaris-ui/Chart.yaml"
+        }
       ]
     }
   },


### PR DESCRIPTION
## Proposed changes

Two places held a version number that nothing kept current:

- `pubspec.yaml` has been `1.0.0+1` across every release so far.
- The license page in the settings advertises `applicationVersion: '0.1.0'` — a
  literal that had not matched the project for a long time, and that only
  someone who opened that dialog would ever notice was wrong.

Both are now annotated and listed in `extra-files`:

```yaml
# pubspec.yaml
version: 1.0.0 # x-release-please-version
```

```dart
// lib/util/constants.dart
/// Release Please rewrites this line, so it always matches the version in
/// pubspec.yaml and the tag the build came from. Do not edit it by hand.
const String appVersion = '1.0.0'; // x-release-please-version
```

```json
"extra-files": [
  { "type": "generic", "path": "pubspec.yaml" },
  "lib/util/constants.dart",
  { "type": "generic", "path": "charts/stelaris-ui/Chart.yaml" }
]
```

One marker, visible in every file it applies to — the same mechanism
`charts/stelaris-ui/Chart.yaml` uses in #125.

### What the marker costs, and why it is still the right call

Release Please has a `dart` release type that updates `pubspec.yaml` natively
and *increments* the build suffix (`1.0.0+1` → `1.1.0+2`), which is the Dart
convention. It cannot be combined with the marker: its updater replaces the
whole line —

```js
content.replace(/^version: .*$/m, `version: ${version}${buildNumber}`)
```

— so the comment would be deleted the first time a release ran. The generic
updater replaces only the version and leaves the rest of the line intact, but it
matches build metadata as part of the version, so `+1` goes with it.

Nothing reads the build number: it is what app stores order releases by, and
this is a web build (`grep` for `build_number`/`buildNumber`/`package_info` in
`lib/`, `web/` and `test/` finds nothing). `pubspec.yaml` is set to `1.0.0` in
this PR rather than leaving the suffix for a release to silently drop, so the
file is already in the shape it will keep.

### Why a constant rather than annotating the widget

`applicationVersion: '0.1.0'` becomes `applicationVersion: appVersion`. Keeping
the magic string out of build code gives Release Please one line to own, next to
`appName` where the other app-level constants already live. `package_info_plus`
would also solve it, at the cost of a dependency and a runtime read for
something known at build time.

### Verified

Rather than trusting a reading of the docs, the `Generic` updater's
`INLINE_UPDATE_REGEX` and `VERSION_REGEX` from
[`src/updaters/generic.ts`](https://github.com/googleapis/release-please/blob/main/src/updaters/generic.ts)
were replayed against the actual files on this branch:

```
pubspec.yaml:
    version: 1.0.0 # x-release-please-version
  -> version: 1.1.0 # x-release-please-version
lib/util/constants.dart:
    const String appVersion = '1.0.0'; // x-release-please-version
  -> const String appVersion = '1.1.0'; // x-release-please-version
```

Replaying it a second time over its own output leaves the marker in place and
moves the version again, so this is stable across releases rather than working
once.

`flutter analyze` reports no issues. 75 tests pass; the two failures in
`test/feature/project/project_selection_page_test.dart` fail identically on
unmodified `develop` and are untouched by this change.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the CONTRIBUTING.md
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

No test: what this changes is what Release Please writes into two files during a
release, which is only observable by cutting one. Both updaters were replayed
against these files instead — see above.

## Also fixes what #125 landed

Rebasing onto `develop` after #125 merged surfaced a second problem, visible in
the open release PR #126:

```diff
-# built from the same commit, so a separate chart version would be a second
-# number to reason about with nothing extra to say.
-version: 1.0.0  # x-release-please-version
-appVersion: "1.0.0"  # x-release-please-version
-
+version: 1.1.0
+appVersion: 1.0.0
```

The comments are deleted, and **`appVersion` keeps its old value** — the chart
would have shipped claiming to deploy an image tag that the release did not
build.

The cause is that a *string* entry in `extra-files` ending in `.yaml` does not
get the marker-based updater. Release Please composes two
([`base.ts`](https://github.com/googleapis/release-please/blob/main/src/strategies/base.ts)):

```js
new GenericYaml('$.version', version),   // parses and re-emits the whole file
new Generic({version, ...})              // only then, the markers
```

`GenericYaml` loads the YAML and dumps it again, so every comment is gone before
the marker updater runs — and it only touches `$.version`, never `appVersion`.

`pubspec.yaml` is a `.yaml` file too, so as a plain string entry it would have
been reserialised the same way, losing `publish_to: 'none' # Remove this line…`
and every other comment in it.

The object form (`{ "type": "generic", "path": … }`) pins the updater, so only
the markers are applied and both files keep their shape.
`lib/util/constants.dart` needs no object form: an extension nothing matches
already falls through to the marker updater.

Simulated against all three files on this branch — four annotated lines, all
updated, comment count unchanged:

```
pubspec.yaml:              version: 1.0.0 -> 1.1.0
lib/util/constants.dart:   appVersion = '1.0.0' -> '1.1.0'
Chart.yaml:                version: 1.0.0 -> 1.1.0
Chart.yaml:                appVersion: "1.0.0" -> "1.1.0"
```

## Further comments

**The open release PR.** #126 (`chore(develop): release 1.1.0`) was generated
under the broken configuration — its Chart.yaml diff is the one quoted above.
Release Please regenerates it on the next push to `develop`, so this needs to
merge before the release is cut, or the released chart goes out with a stale
`appVersion` and no comments.
