### PR TITLE
fix(docker): make the deployed image actually boot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,13 @@ COPY --chown=builder:builder . .
 # so the generator runs here the same way it runs in CI.
 RUN dart run build_runner build --delete-conflicting-outputs
 
-RUN flutter build web --release --wasm
+# --no-web-resources-cdn, because `--web-resources-cdn` defaults to on: the
+# build writes the CanvasKit and Skwasm files into the bundle either way, but
+# the loader then fetches them from www.gstatic.com at runtime and the copies in
+# the image are never touched. That puts a third-party host on the critical path
+# of an image whose whole point is not having one, and it needs a CSP wide
+# enough to let a compromised dependency talk to that host too.
+RUN flutter build web --release --wasm --no-web-resources-cdn
 
 # Precompress once, here, instead of spending CPU on it for every request.
 # `gzip_static` picks the .gz sibling up and falls back to the plain file for

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -36,6 +36,15 @@ http {
     include      /etc/nginx/mime.types;
     default_type application/octet-stream;
 
+    # nginx ships no mapping for .mjs, so the Wasm entrypoint main.dart.mjs
+    # would go out as application/octet-stream - and a browser refuses to
+    # execute an ES module that is not served with a JavaScript MIME type, which
+    # stops the app from booting at all. A second `types` block adds to the
+    # included map rather than replacing it.
+    types {
+        text/javascript mjs;
+    }
+
     # The nginx version in Server: and on error pages is free reconnaissance
     # for anyone scanning for a known CVE.
     server_tokens off;

--- a/docs/docker-image.md
+++ b/docs/docker-image.md
@@ -157,6 +157,19 @@ Behaviour worth knowing:
 broken build stays visible instead of answering a missing script with a page of
 HTML and a console message about an unexpected MIME type.
 
+**Everything is served from the image.** `flutter build web` defaults to
+`--web-resources-cdn`, which writes CanvasKit and Skwasm into the bundle *and*
+makes the loader fetch them from `www.gstatic.com` at runtime, so the copies in
+the image are never touched. The build passes `--no-web-resources-cdn` to turn
+that off. Without it the renderer comes from a third-party host on every page
+load — an odd thing for an image whose point is not having one — and the CSP has
+to be wide enough to permit it, which also permits a compromised dependency to
+talk to that host.
+
+The symptom, if this ever regresses, is the app failing to boot with
+`Connecting to 'https://www.gstatic.com/flutter-canvaskit/…/skwasm.wasm'
+violates the following Content Security Policy directive` in the console.
+
 **`application/wasm`.** `WebAssembly.instantiateStreaming` rejects anything
 else. It comes from the base image's `mime.types`, so it holds as long as the
 bundle is served by nginx at all.


### PR DESCRIPTION
## Proposed changes

The deployed 1.1.0 image does not boot. Two independent bugs, the second hidden
behind the first:

```
Connecting to 'https://www.gstatic.com/flutter-canvaskit/…/skwasm.wasm' violates
the following Content Security Policy directive: "connect-src 'self' https://vulpes-backend…"
Failed to fetch dynamically imported module: https://stelaris.apps.onelite.feather/main.dart.mjs
```

### 1. The renderer came from a CDN

`flutter build web` defaults to `--web-resources-cdn`. That writes CanvasKit and
Skwasm **into the bundle** — all 22 files are in the image — and then has the
loader fetch them from `www.gstatic.com` anyway, so the copies are never
touched.

Two things follow. The renderer arrives from a third-party host on every page
load, which is a strange dependency for an image whose point is not having one.
And the CSP has to be wide enough to allow that host — the same channel a
compromised dependency would use to send data somewhere.

So the fix is `--no-web-resources-cdn`, not another CSP directive. The files
were already being shipped; now they are also used.

The build config is the observable difference — `"useLocalCanvasKit":true`
appears where the key was previously absent. The `gstatic` string stays in
`flutter.js` as the untaken branch of a ternary, which is expected.

### 2. `.mjs` was served as `application/octet-stream`

nginx ships no mapping for `.mjs`, so `main.dart.mjs` went out as
`application/octet-stream` — and a browser refuses to execute an ES module that
is not served with a JavaScript MIME type. **The Wasm build never started.**

This was invisible until the first bug was fixed, because the CanvasKit failure
aborted the boot earlier. Fixing only the CDN would have moved the error, not
removed it.

A second `types` block adds to the included map rather than replacing it —
`index.html` still resolves through `mime.types` as before.

## Verified

Both fixes were checked end to end in a real browser against the built image,
run under the same restrictions the cluster applies:

- `main.dart.wasm` and `skwasm.js` are now fetched from **the image's own
  origin**, not gstatic (network log: `GET /canvaskit/skwasm.wasm 200`,
  `GET /canvaskit/skwasm.js 200`)
- `main.dart.mjs` is served as `text/javascript` and executes; the router
  reaches `#/projects` and the app renders
- No CSP violation in the console
- Every file in the bundle was walked and its `Content-Type` checked. Nothing
  the browser enforces a MIME type for — `.js`, `.mjs`, `.wasm`, `.json`,
  `.css`, `.html` — is `octet-stream` any more.

What still comes back as `octet-stream`: `NOTICES`, `AssetManifest.bin`, the
`.ttf`/`.otf` fonts, the `.frag` shaders and the `.symbols` files. Flutter
fetches all of those as binary and hands them on itself, so no browser check
applies. Left alone deliberately rather than added as unrelated churn.

The only console output left locally is a Dart exception from the API call,
because no backend runs on a laptop, plus Flutter's standing note that
multi-threaded Skwasm needs cross-origin isolation — COEP is off on purpose,
see `docs/docker-image.md`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the CONTRIBUTING.md
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

No test: the pull-request job builds the image but no longer exercises it, so
there is nowhere for an assertion about a served `Content-Type` or a fetched URL
to live. Both bugs are exactly the class that the removed behaviour checks would
have caught — the wasm content-type assertion was one of them. Worth weighing
again; the chart's `helm test` pod is currently the only place running behaviour
is checked at all.

## Further comments

`docs/docker-image.md` records both, including the console message each one
produces, so the next person recognises them rather than re-deriving them.

Once released, the two `OCIRepository` pins in
[Kubernetes-FLUX#220](https://github.com/OneLiteFeatherNET/Kubernetes-FLUX/pull/220)
need bumping to the new version.
