### PR TITLE
fix(build): send projectId when downloading a generated code base

### DIFF
--- a/lib/api/service/generate_api.dart
+++ b/lib/api/service/generate_api.dart
@@ -27,8 +27,11 @@ class GenerateApi {
     return (data as List<dynamic>).map((e) => e as String).toList();
   }
 
-  Future<(List<int>, String)> download(String branch) async {
-    final queryParams = <String, dynamic>{'branch': branch};
+  Future<(List<int>, String)> download(String branch, String projectId) async {
+    final queryParams = <String, dynamic>{
+      'branch': branch,
+      'projectId': projectId,
+    };
     final baseUri = Uri.parse(_apiClient.baseUrl);
     final uri = baseUri.replace(
       queryParameters: queryParams,

--- a/lib/api/state/factory/build/build_vm_state.dart
+++ b/lib/api/state/factory/build/build_vm_state.dart
@@ -16,6 +16,7 @@ class BuildStateFactory
     branches: state.branches,
     isLoadingRelease: state.isLoadingRelease,
     isLoadingBranches: state.isLoadingBranches,
+    projectId: state.selectedProject?.id,
     onRefreshBranches: () => dispatch(BranchFetchAction()),
   );
 }
@@ -26,15 +27,23 @@ class BuildViewModel extends Vm {
     required this.branches,
     required this.isLoadingRelease,
     required this.isLoadingBranches,
+    required this.projectId,
     required this.onRefreshBranches,
   }) : super(
-         equals: [releaseModel, branches, isLoadingRelease, isLoadingBranches],
+         equals: [
+           releaseModel,
+           branches,
+           isLoadingRelease,
+           isLoadingBranches,
+           projectId,
+         ],
        );
 
   final ReleaseModel? releaseModel;
   final List<String>? branches;
   final bool isLoadingRelease;
   final bool isLoadingBranches;
+  final String? projectId;
   final VoidCallback onRefreshBranches;
 
   String get version => releaseModel == null ? '0.0.1' : releaseModel!.version;

--- a/lib/feature/build/build_dialog.dart
+++ b/lib/feature/build/build_dialog.dart
@@ -50,6 +50,7 @@ class BuildDialog extends StatelessWidget {
                       DownloadTrigger(
                         branches: vm.branches,
                         isLoading: vm.isLoadingBranches,
+                        projectId: vm.projectId,
                         onRefresh: vm.onRefreshBranches,
                       ),
                       BuildTrigger(version: vm.version),

--- a/lib/feature/build/download/download_trigger.dart
+++ b/lib/feature/build/download/download_trigger.dart
@@ -13,12 +13,17 @@ import 'download_helper.dart';
 class DownloadTrigger extends StatefulWidget {
   const DownloadTrigger({
     required this.branches,
+    required this.projectId,
     this.isLoading = false,
     this.onRefresh,
     super.key,
   });
 
   final List<String>? branches;
+
+  /// Id of the currently selected project. The generator requires it to know
+  /// which project's data to render into the downloaded code base.
+  final String? projectId;
   final bool isLoading;
   final VoidCallback? onRefresh;
 
@@ -85,6 +90,21 @@ class _DownloadTriggerState extends State<DownloadTrigger> {
               height: 16,
               child: CircularProgressIndicator(strokeWidth: 2),
             ),
+          ),
+        ),
+      );
+    }
+
+    final projectId = widget.projectId;
+    if (projectId == null || projectId.isEmpty) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: StatusCard(
+            text: 'No project selected! Please select a project first',
+            backgroundColor: theme.colorScheme.errorContainer,
+            glowColor: theme.colorScheme.errorContainer.withValues(alpha: 0.5),
+            height: 70,
           ),
         ),
       );
@@ -202,7 +222,7 @@ class _DownloadTriggerState extends State<DownloadTrigger> {
                       .showSnackBar(InfoBarFactory().create(text));
 
                   final (data, filename) = await ApiService().generateApi
-                      .download(value);
+                      .download(value, projectId);
 
                   final content = base64Encode(data);
 

--- a/test/api/service/generate_api_test.dart
+++ b/test/api/service/generate_api_test.dart
@@ -42,6 +42,20 @@ void main() {
   });
 
   group('download', () {
+    test('GETs /download with branch and projectId query params', () async {
+      final adapter = _BytesAdapter(utf8.encode('zip-content'));
+      apiClient.dio.httpClientAdapter = adapter;
+
+      await generateApi.download('main', 'project-1');
+
+      expect(adapter.lastRequest!.method, 'GET');
+      expect(adapter.lastRequest!.uri.path, '/api/download');
+      expect(adapter.lastRequest!.uri.queryParameters, {
+        'branch': 'main',
+        'projectId': 'project-1',
+      });
+    });
+
     test('uses the filename from Content-Disposition when present', () async {
       final bytes = utf8.encode('zip-content');
       apiClient.dio.httpClientAdapter = _BytesAdapter(
@@ -51,7 +65,7 @@ void main() {
         },
       );
 
-      final (data, filename) = await generateApi.download('main');
+      final (data, filename) = await generateApi.download('main', 'project-1');
 
       expect(data, bytes);
       expect(filename, 'custom.zip');
@@ -61,7 +75,10 @@ void main() {
       final bytes = utf8.encode('zip-content');
       apiClient.dio.httpClientAdapter = _BytesAdapter(bytes);
 
-      final (data, filename) = await generateApi.download('feature/x');
+      final (data, filename) = await generateApi.download(
+        'feature/x',
+        'project-1',
+      );
 
       expect(data, bytes);
       expect(filename, 'vulpes-feature/x.zip');
@@ -84,20 +101,26 @@ void main() {
   });
 }
 
-/// A [HttpClientAdapter] fake that responds with raw [bytes] and optional
-/// [headers], for endpoints using [ResponseType.bytes].
+/// A [HttpClientAdapter] fake that records the [RequestOptions] of the last
+/// request and responds with raw [bytes] and optional [headers], for
+/// endpoints using [ResponseType.bytes].
 class _BytesAdapter implements HttpClientAdapter {
   _BytesAdapter(this.bytes, {this.headers = const {}});
 
   final List<int> bytes;
   final Map<String, List<String>> headers;
 
+  RequestOptions? lastRequest;
+
   @override
   Future<ResponseBody> fetch(
     RequestOptions options,
     Stream<Uint8List>? requestStream,
     Future<void>? cancelFuture,
-  ) async => ResponseBody.fromBytes(bytes, 200, headers: headers);
+  ) async {
+    lastRequest = options;
+    return ResponseBody.fromBytes(bytes, 200, headers: headers);
+  }
 
   @override
   void close({bool force = false}) {}


### PR DESCRIPTION
## Proposed changes

Downloading a generated code base always failed with:

```json
{"message":"Bad Request","_embedded":{"errors":[{"message":"Required QueryValue [projectId] not specified","path":"/projectId"}]}}
```

The generator requires a `projectId` on `/download` since it gained project scoping:

```java
// vulpes-generator: VulpesDownloadController#download
@QueryValue(value = "branch", defaultValue = "develop") String branch,
@QueryValue(value = "projectId") UUID projectId
```

Stelaris only sent `branch`.

Changes:

- `GenerateApi.download` takes the `projectId` and appends it as a query parameter.
- `BuildViewModel` exposes `state.selectedProject?.id` and includes it in `equals`, so switching projects rebuilds the dialog.
- `BuildDialog` passes the id down to the `DownloadTrigger`.
- The `DownloadTrigger` renders a `StatusCard` instead of the form while no project is selected — otherwise the button is guaranteed to hit the same 400.

Not affected: `/git/branches` and `/build/data` take no `projectId`. Neither does `/generator/generate` — that endpoint has separate problems (the client calls `/generate` instead of `/generator/generate`, and the required `image` parameter is never sent), deliberately left out of this PR.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

⚠️ No Flutter/Dart SDK was available on the development machine, so `flutter analyze` and `flutter test` **could not be run locally**. The changes were verified statically (all call sites updated). Please watch the CI run.

The new test in `test/api/service/generate_api_test.dart` asserts that `/download` is called with both `branch` and `projectId`; `_BytesAdapter` now records the request for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
