### PR TITLE
fix(ci): publish the Helm chart only after the image

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -78,7 +78,11 @@ jobs:
   # needs no chart of its own.
   helm:
     name: Publish the Helm chart
-    needs: release-please
+    # Also on `docker`, not just on the release: the chart is packaged with the
+    # release version as its appVersion, so pushing it before the image exists
+    # publishes a chart that points at a tag nobody can pull yet - and leaves
+    # one published for good if the image build fails.
+    needs: [release-please, docker]
     if: needs.release-please.outputs.release_created == 'true'
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Proposed changes

The `helm` job only depended on `release-please`, so it ran in parallel with `docker`:

| job | depends on | takes |
|---|---|---|
| `docker` | `release-please` | minutes (build, chunked Harbor upload, cosign) |
| `helm` | `release-please` | seconds (`helm package` + `helm push`) |

The chart is packaged with the release version as its `appVersion`, so it was reliably published pointing at an image tag that did not exist yet. Flux pulling in that window gets `ImagePullBackOff` — and if the image build fails outright, a chart referencing an image that will never exist stays published.

The existing comment in this file claims exactly the guarantee that was missing:

> Both versions come from the release rather than from Chart.yaml. […] the chart cannot be packaged pointing at an image tag nobody built.

That holds for the *version number* — it comes from the same release — but not for the *existence* of the image.

Adding `docker` to `needs` closes the gap, and since `needs` implies success, it also stops the chart from being published when the image build fails. The `if` condition is unchanged; `needs.release-please.outputs` still resolves.

The same fix applies to Vulpes-Backend, where the gap is even wider because `docker` additionally waits for `build-context` — filed separately.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the CONTRIBUTING.md
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Not covered by tests — the ordering only shows up in a real release run. It can be confirmed on the next release: the `Publish the Helm chart` job must start only after `Publish the image` has finished.

Trade-off: the chart push now waits for the image build, so a release takes longer end to end. That is the intended semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
