### PR TITLE
feat(project): allow the edit of projects

### DIFF
--- a/lib/api/state/factory/project/project_vm_state.dart
+++ b/lib/api/state/factory/project/project_vm_state.dart
@@ -7,29 +7,42 @@ import 'package:stelaris_models/stelaris_models.dart';
 
 class ProjectVmFactory
     extends VmFactory<AppState, ProjectSelectionPage, ProjectViewModel> {
-  ProjectVmFactory();
+  final Project? localSelection;
+
+  ProjectVmFactory({this.localSelection});
 
   @override
   ProjectViewModel fromStore() => ProjectViewModel(
     projects: state.projects,
-    selectedProject: state.selectedProject,
+    selected: _resolveSelected(
+      state.projects,
+      localSelection ?? state.selectedProject,
+    ),
     onSelectProject: (project) => dispatch(SelectProjectAction(project)),
   );
+
+  // A project's id is only assigned once persisted, so a project picked
+  // locally before the store reconciles it must also be matched by key.
+  Project? _resolveSelected(List<Project> projects, Project? candidate) {
+    if (projects.isEmpty) return null;
+    if (candidate != null) {
+      final match = projects
+          .where((p) => p.id == candidate.id || p.key == candidate.key)
+          .firstOrNull;
+      if (match != null) return match;
+    }
+    return projects.first;
+  }
 }
 
 class ProjectViewModel extends Vm {
   final List<Project> projects;
-  final Project? selectedProject;
+  final Project? selected;
   final ValueChanged<Project?> onSelectProject;
 
   ProjectViewModel({
     required this.projects,
-    required this.selectedProject,
+    required this.selected,
     required this.onSelectProject,
-  }) : super(equals: [projects, selectedProject]);
-
-  bool isSelected(Project project) {
-    if (selectedProject == null) return false;
-    return selectedProject!.id == project.id;
-  }
+  }) : super(equals: [projects, selected]);
 }

--- a/lib/feature/project/badge/project_app_bar_badge.dart
+++ b/lib/feature/project/badge/project_app_bar_badge.dart
@@ -1,6 +1,7 @@
 import 'package:async_redux/async_redux.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:stelaris/api/state/app_state.dart';
+import 'package:stelaris/feature/project/badge/project_labor_badge.dart';
 import 'package:stelaris/feature/settings/settings_dialog.dart';
 import 'package:stelaris_models/stelaris_models.dart';
 
@@ -56,24 +57,7 @@ class ProjectAppBarBadge extends StatelessWidget {
                     ),
                     if (project.labor) ...[
                       const SizedBox(width: 8),
-                      Container(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 6,
-                          vertical: 2,
-                        ),
-                        decoration: BoxDecoration(
-                          color: colorScheme.tertiaryContainer,
-                          borderRadius: BorderRadius.circular(4),
-                        ),
-                        child: Text(
-                          'LABOR',
-                          style: TextStyle(
-                            fontSize: 9,
-                            fontWeight: FontWeight.bold,
-                            color: colorScheme.onTertiaryContainer,
-                          ),
-                        ),
-                      ),
+                      const ProjectLaborBadge(),
                     ],
                   ],
                 ),

--- a/lib/feature/project/badge/project_labor_badge.dart
+++ b/lib/feature/project/badge/project_labor_badge.dart
@@ -1,0 +1,31 @@
+import 'package:material_ui/material_ui.dart';
+
+class ProjectLaborBadge extends StatelessWidget {
+  final double fontSize;
+
+  const ProjectLaborBadge({
+    super.key,
+    this.fontSize = 9,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: colorScheme.tertiaryContainer,
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        'Labor',
+        style: TextStyle(
+          fontSize: fontSize,
+          fontWeight: FontWeight.bold,
+          color: colorScheme.onTertiaryContainer,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/feature/project/dialog/project_edit_dialog.dart
+++ b/lib/feature/project/dialog/project_edit_dialog.dart
@@ -2,28 +2,43 @@ import 'package:async_redux/async_redux.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:stelaris/api/state/actions/project/project_actions.dart';
 import 'package:stelaris/util/constants.dart';
-import 'package:stelaris/util/formatter/formatters.dart';
 import 'package:stelaris/util/l10n_ext.dart';
 import 'package:stelaris/util/validators.dart';
 import 'package:stelaris_models/stelaris_models.dart';
 
 import 'project_form_dialog.dart';
 
-class CreateProjectDialog extends StatefulWidget {
-  const CreateProjectDialog({super.key});
+class EditProjectDialog extends StatefulWidget {
+  final Project project;
+
+  const EditProjectDialog({
+    super.key,
+    required this.project,
+  });
 
   @override
-  State<CreateProjectDialog> createState() => _CreateProjectDialogState();
+  State<EditProjectDialog> createState() => _EditProjectDialogState();
 }
 
-class _CreateProjectDialogState extends State<CreateProjectDialog> {
+class _EditProjectDialogState extends State<EditProjectDialog> {
   final _formKey = GlobalKey<FormState>();
-  final _displayNameController = TextEditingController();
-  final _keyController = TextEditingController();
-  final _descriptionController = TextEditingController();
-  final _projectUrlController = TextEditingController();
-  final _docuUrlController = TextEditingController();
-  bool _labor = false;
+  late final TextEditingController _displayNameController;
+  late final TextEditingController _keyController;
+  late final TextEditingController _descriptionController;
+  late final TextEditingController _projectUrlController;
+  late final TextEditingController _docuUrlController;
+  late bool _labor;
+
+  @override
+  void initState() {
+    super.initState();
+    _displayNameController = TextEditingController(text: widget.project.displayName);
+    _keyController = TextEditingController(text: widget.project.key);
+    _descriptionController = TextEditingController(text: widget.project.description ?? '');
+    _projectUrlController = TextEditingController(text: widget.project.projectUrl ?? '');
+    _docuUrlController = TextEditingController(text: widget.project.docuUrl ?? '');
+    _labor = widget.project.labor;
+  }
 
   @override
   void dispose() {
@@ -38,10 +53,10 @@ class _CreateProjectDialogState extends State<CreateProjectDialog> {
   @override
   Widget build(BuildContext context) {
     return ProjectFormDialog(
-      title: context.l10n.dialog_project_create_title,
-      actionIcon: Icons.add,
-      actionLabel: context.l10n.dialog_project_create_button,
-      onSubmit: _handleCreate,
+      title: context.l10n.dialog_project_edit_title,
+      actionIcon: Icons.save_outlined,
+      actionLabel: context.l10n.dialog_project_edit_button,
+      onSubmit: _handleSave,
       content: Form(
         key: _formKey,
         child: Column(
@@ -61,15 +76,14 @@ class _CreateProjectDialogState extends State<CreateProjectDialog> {
             verticalSpacing10,
             TextFormField(
               controller: _keyController,
-              autovalidateMode: AutovalidateMode.onUserInteraction,
-              inputFormatters: const [lowerCaseFormatter],
+              readOnly: true,
+              enabled: false,
               decoration: InputDecoration(
-                labelText: '${context.l10n.dialog_project_key} *',
-                hintText: 'e.g. my_project',
+                labelText: context.l10n.dialog_project_key,
                 border: const OutlineInputBorder(),
-                prefixIcon: const Icon(Icons.vpn_key_outlined),
+                prefixIcon: const Icon(Icons.lock_outline),
+                helperText: context.l10n.dialog_project_key_readonly_hint,
               ),
-              validator: Validators.adventureNamespace(),
             ),
             verticalSpacing10,
             TextFormField(
@@ -123,27 +137,25 @@ class _CreateProjectDialogState extends State<CreateProjectDialog> {
     );
   }
 
-  void _handleCreate() async {
+  void _handleSave() async {
     if (!_formKey.currentState!.validate()) return;
 
-    final key = _keyController.text.trim();
     final displayName = _displayNameController.text.trim();
     final desc = _descriptionController.text.trim();
     final projectUrl = _projectUrlController.text.trim();
     final docuUrl = _docuUrlController.text.trim();
 
-    final newProject = Project(
+    final updatedProject = widget.project.copyWith(
       displayName: displayName,
-      key: key,
       description: desc.isEmpty ? null : desc,
       projectUrl: projectUrl.isEmpty ? null : projectUrl,
       docuUrl: docuUrl.isEmpty ? null : docuUrl,
       labor: _labor,
     );
 
-    await context.dispatchAndWait(AddProjectAction(newProject, select: true));
+    await context.dispatchAndWait(UpdateProjectAction(updatedProject));
     if (mounted) {
-      Navigator.of(context).pop(newProject);
+      Navigator.of(context).pop(updatedProject);
     }
   }
 }

--- a/lib/feature/project/dialog/project_form_dialog.dart
+++ b/lib/feature/project/dialog/project_form_dialog.dart
@@ -1,0 +1,75 @@
+import 'package:material_ui/material_ui.dart';
+import 'package:stelaris/util/constants.dart';
+import 'package:stelaris/util/l10n_ext.dart';
+
+class ProjectFormDialog extends StatelessWidget {
+  final String title;
+  final Widget content;
+  final IconData actionIcon;
+  final String actionLabel;
+  final VoidCallback onSubmit;
+
+  const ProjectFormDialog({
+    super.key,
+    required this.title,
+    required this.content,
+    required this.actionIcon,
+    required this.actionLabel,
+    required this.onSubmit,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Dialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 550, maxHeight: 700),
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text(
+                    title,
+                    style: theme.textTheme.titleLarge?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  IconButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    icon: const Icon(Icons.close),
+                    splashRadius: 20,
+                  ),
+                ],
+              ),
+              const Divider(height: 24),
+              Flexible(child: SingleChildScrollView(child: content)),
+              const Divider(height: 24),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  TextButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    child: Text(context.l10n.button_cancel),
+                  ),
+                  horizontalSpacing10,
+                  FilledButton.icon(
+                    onPressed: onSubmit,
+                    icon: Icon(actionIcon),
+                    label: Text(actionLabel),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/feature/project/parts/empty_project_view.dart
+++ b/lib/feature/project/parts/empty_project_view.dart
@@ -1,0 +1,59 @@
+import 'package:material_ui/material_ui.dart';
+import 'package:stelaris/util/constants.dart';
+import 'package:stelaris/util/l10n_ext.dart';
+
+class EmptyProjectView extends StatelessWidget {
+  final VoidCallback onCreateProject;
+
+  const EmptyProjectView({
+    super.key,
+    required this.onCreateProject,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 24),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.create_new_folder_outlined,
+            size: 56,
+            color: colorScheme.outline,
+          ),
+          verticalSpacing10,
+          Text(
+            context.l10n.project_selection_empty_title,
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          heightTen,
+          Text(
+            context.l10n.project_selection_empty_subtitle,
+            textAlign: TextAlign.center,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: colorScheme.onSurfaceVariant,
+            ),
+          ),
+          verticalSpacing25,
+          FilledButton.icon(
+            onPressed: onCreateProject,
+            style: FilledButton.styleFrom(
+              padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 14),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
+            ),
+            icon: const Icon(Icons.add),
+            label: Text(context.l10n.dialog_project_create_button),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/feature/project/parts/project_list_tile.dart
+++ b/lib/feature/project/parts/project_list_tile.dart
@@ -1,0 +1,87 @@
+import 'package:material_ui/material_ui.dart';
+import 'package:stelaris/feature/project/badge/project_labor_badge.dart';
+import 'package:stelaris/util/l10n_ext.dart';
+import 'package:stelaris_models/stelaris_models.dart';
+
+class ProjectListTile extends StatelessWidget {
+  final Project project;
+  final bool isSelected;
+  final VoidCallback onSelect;
+  final VoidCallback onEdit;
+
+  const ProjectListTile({
+    super.key,
+    required this.project,
+    required this.isSelected,
+    required this.onSelect,
+    required this.onEdit,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Material(
+      color: isSelected
+          ? colorScheme.surfaceContainerHighest.withValues(alpha: 0.5)
+          : Colors.transparent,
+      child: ListTile(
+        dense: true,
+        contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 2),
+        leading: Icon(
+          isSelected ? Icons.folder : Icons.folder_outlined,
+          color: isSelected
+              ? colorScheme.primary
+              : colorScheme.onSurfaceVariant.withValues(alpha: 0.7),
+          size: 22,
+        ),
+        title: Row(
+          children: [
+            Flexible(
+              child: Text(
+                project.displayName,
+                style: TextStyle(
+                  fontWeight: isSelected ? FontWeight.w600 : FontWeight.w500,
+                  fontSize: 14,
+                  color: colorScheme.onSurface,
+                ),
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+            const SizedBox(width: 6),
+            Text(
+              '(${project.key})',
+              style: TextStyle(
+                fontSize: 12,
+                color: colorScheme.onSurfaceVariant,
+              ),
+            ),
+            if (project.labor) ...[
+              const SizedBox(width: 8),
+              const ProjectLaborBadge(),
+            ],
+          ],
+        ),
+        subtitle: project.description != null && project.description!.isNotEmpty
+            ? Text(
+                project.description!,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              )
+            : null,
+        trailing: IconButton(
+          icon: const Icon(Icons.edit_outlined, size: 18),
+          tooltip: context.l10n.project_selection_edit_tooltip,
+          splashRadius: 18,
+          color: colorScheme.onSurfaceVariant.withValues(alpha: 0.8),
+          onPressed: onEdit,
+        ),
+        onTap: onSelect,
+      ),
+    );
+  }
+}

--- a/lib/feature/project/parts/project_selection_card.dart
+++ b/lib/feature/project/parts/project_selection_card.dart
@@ -1,0 +1,82 @@
+import 'package:material_ui/material_ui.dart';
+import 'package:stelaris/util/constants.dart';
+import 'package:stelaris/util/l10n_ext.dart';
+import 'package:stelaris_models/stelaris_models.dart';
+
+import 'empty_project_view.dart';
+import 'project_selection_header.dart';
+import 'project_selector_list.dart';
+
+class ProjectSelectionCard extends StatelessWidget {
+  final List<Project> projects;
+  final Project? selected;
+  final ValueChanged<Project> onSelectProject;
+  final ValueChanged<Project> onEditProject;
+  final VoidCallback onCreateProject;
+  final VoidCallback onProceed;
+
+  const ProjectSelectionCard({
+    super.key,
+    required this.projects,
+    required this.selected,
+    required this.onSelectProject,
+    required this.onEditProject,
+    required this.onCreateProject,
+    required this.onProceed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Card(
+      elevation: 6,
+      shadowColor: colorScheme.shadow.withValues(alpha: 0.2),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: SizedBox(
+        width: 520,
+        child: Padding(
+          padding: const EdgeInsets.all(28),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              ProjectSelectionHeader(
+                showAddButton: projects.isNotEmpty,
+                onCreateProject: onCreateProject,
+              ),
+              const Divider(height: 32),
+              if (projects.isEmpty) ...[
+                EmptyProjectView(onCreateProject: onCreateProject),
+              ] else ...[
+                ProjectSelectorList(
+                  projects: projects,
+                  selected: selected,
+                  onSelect: onSelectProject,
+                  onEdit: onEditProject,
+                ),
+                verticalSpacing25,
+                FilledButton.icon(
+                  onPressed: selected == null ? null : onProceed,
+                  style: FilledButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 16),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                  ),
+                  icon: const Icon(Icons.arrow_forward),
+                  label: Text(
+                    context.l10n.project_selection_open_button,
+                    style: const TextStyle(fontSize: 16),
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/feature/project/parts/project_selection_header.dart
+++ b/lib/feature/project/parts/project_selection_header.dart
@@ -1,0 +1,48 @@
+import 'package:material_ui/material_ui.dart';
+import 'package:stelaris/util/constants.dart';
+import 'package:stelaris/util/l10n_ext.dart';
+
+class ProjectSelectionHeader extends StatelessWidget {
+  final bool showAddButton;
+  final VoidCallback onCreateProject;
+
+  const ProjectSelectionHeader({
+    super.key,
+    required this.showAddButton,
+    required this.onCreateProject,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Row(
+          children: [
+            Icon(
+              Icons.folder_shared_outlined,
+              color: colorScheme.primary,
+              size: 26,
+            ),
+            horizontalSpacing10,
+            Text(
+              context.l10n.project_selection_title,
+              style: theme.textTheme.titleLarge?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
+        ),
+        if (showAddButton)
+          IconButton.filledTonal(
+            tooltip: context.l10n.dialog_project_create_title,
+            icon: const Icon(Icons.add),
+            onPressed: onCreateProject,
+          ),
+      ],
+    );
+  }
+}

--- a/lib/feature/project/parts/project_selector_list.dart
+++ b/lib/feature/project/parts/project_selector_list.dart
@@ -1,0 +1,91 @@
+import 'package:material_ui/material_ui.dart';
+import 'package:stelaris/util/constants.dart';
+import 'package:stelaris/util/l10n_ext.dart';
+import 'package:stelaris_models/stelaris_models.dart';
+
+import 'project_list_tile.dart';
+
+class ProjectSelectorList extends StatefulWidget {
+  final List<Project> projects;
+  final Project? selected;
+  final ValueChanged<Project> onSelect;
+  final ValueChanged<Project> onEdit;
+
+  const ProjectSelectorList({
+    super.key,
+    required this.projects,
+    required this.selected,
+    required this.onSelect,
+    required this.onEdit,
+  });
+
+  @override
+  State<ProjectSelectorList> createState() => _ProjectSelectorListState();
+}
+
+class _ProjectSelectorListState extends State<ProjectSelectorList> {
+  final _scrollController = ScrollController();
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          context.l10n.project_selection_dropdown_label,
+          style: theme.textTheme.labelLarge?.copyWith(
+            color: colorScheme.onSurfaceVariant,
+          ),
+        ),
+        heightTen,
+        // Sunken / Recessed Container
+        Material(
+          color: colorScheme.surfaceContainerLowest,
+          borderRadius: BorderRadius.circular(12),
+          clipBehavior: Clip.antiAlias,
+          child: Container(
+            constraints: const BoxConstraints(maxHeight: 280, minHeight: 80),
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(
+                color: colorScheme.outlineVariant.withValues(alpha: 0.6),
+              ),
+            ),
+            child: Scrollbar(
+              controller: _scrollController,
+              thumbVisibility: true,
+              child: ListView.separated(
+                controller: _scrollController,
+                shrinkWrap: true,
+                itemCount: widget.projects.length,
+                separatorBuilder: (context, index) => Divider(
+                  height: 1,
+                  thickness: 1,
+                  color: colorScheme.outlineVariant.withValues(alpha: 0.3),
+                ),
+                itemBuilder: (context, index) {
+                  final project = widget.projects[index];
+                  return ProjectListTile(
+                    project: project,
+                    isSelected: widget.selected?.id == project.id,
+                    onSelect: () => widget.onSelect(project),
+                    onEdit: () => widget.onEdit(project),
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/feature/project/project_selection_page.dart
+++ b/lib/feature/project/project_selection_page.dart
@@ -10,6 +10,8 @@ import 'package:stelaris/util/l10n_ext.dart';
 import 'package:stelaris_models/stelaris_models.dart';
 
 import 'dialog/project_create_dialog.dart';
+import 'dialog/project_edit_dialog.dart';
+import 'parts/project_selection_card.dart';
 
 class ProjectSelectionPage extends StatefulWidget {
   const ProjectSelectionPage({super.key});
@@ -29,18 +31,8 @@ class _ProjectSelectionPageState extends State<ProjectSelectionPage> {
     return Scaffold(
       body: StoreConnector<AppState, ProjectViewModel>(
         onInit: (store) => store.dispatchAndWait(InitProjectAction()),
-        vm: () => ProjectVmFactory(),
+        vm: () => ProjectVmFactory(localSelection: _selected),
         builder: (context, vm) {
-          // Sync local selection with state if null or removed
-          if (_selected == null && vm.selectedProject != null) {
-            _selected = vm.selectedProject;
-          } else if (_selected != null &&
-              !vm.projects.any((p) => p.id == _selected!.id)) {
-            _selected = vm.projects.isNotEmpty ? vm.projects.first : null;
-          } else if (_selected == null && vm.projects.isNotEmpty) {
-            _selected = vm.projects.first;
-          }
-
           return Center(
             child: SingleChildScrollView(
               padding: const EdgeInsets.all(24),
@@ -68,77 +60,15 @@ class _ProjectSelectionPageState extends State<ProjectSelectionPage> {
                     ),
                   ),
                   verticalSpacing25,
-
-                  // Elevated Selection Card
-                  Card(
-                    elevation: 6,
-                    shadowColor: colorScheme.shadow.withValues(alpha: 0.2),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(20),
-                    ),
-                    child: Container(
-                      width: 480,
-                      padding: const EdgeInsets.all(28),
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
-                        children: [
-                          // Card Header with + Button (only shown when projects exist)
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: [
-                              Row(
-                                children: [
-                                  Icon(
-                                    Icons.folder_shared_outlined,
-                                    color: colorScheme.primary,
-                                    size: 26,
-                                  ),
-                                  horizontalSpacing10,
-                                  Text(
-                                    context.l10n.project_selection_title,
-                                    style: theme.textTheme.titleLarge?.copyWith(
-                                      fontWeight: FontWeight.bold,
-                                    ),
-                                  ),
-                                ],
-                              ),
-                              if (vm.projects.isNotEmpty)
-                                IconButton.filledTonal(
-                                  tooltip: context.l10n.dialog_project_create_title,
-                                  icon: const Icon(Icons.add),
-                                  onPressed: () => _openCreateDialog(context),
-                                ),
-                            ],
-                          ),
-                          const Divider(height: 32),
-
-                          // Card Body
-                          if (vm.projects.isEmpty) ...[
-                            _buildEmptyState(context, colorScheme, theme),
-                          ] else ...[
-                            _buildProjectSelector(context, vm, colorScheme, theme),
-                            verticalSpacing25,
-                            FilledButton.icon(
-                              onPressed: _selected == null
-                                  ? null
-                                  : () => _proceedWithProject(vm),
-                              style: FilledButton.styleFrom(
-                                padding: const EdgeInsets.symmetric(vertical: 16),
-                                shape: RoundedRectangleBorder(
-                                  borderRadius: BorderRadius.circular(12),
-                                ),
-                              ),
-                              icon: const Icon(Icons.arrow_forward),
-                              label: Text(
-                                context.l10n.project_selection_open_button,
-                                style: const TextStyle(fontSize: 16),
-                              ),
-                            ),
-                          ],
-                        ],
-                      ),
-                    ),
+                  ProjectSelectionCard(
+                    projects: vm.projects,
+                    selected: vm.selected,
+                    onSelectProject: (project) =>
+                        setState(() => _selected = project),
+                    onEditProject: (project) =>
+                        _openEditDialog(context, project),
+                    onCreateProject: () => _openCreateDialog(context),
+                    onProceed: () => _proceedWithProject(vm, vm.selected!),
                   ),
                 ],
               ),
@@ -149,227 +79,27 @@ class _ProjectSelectionPageState extends State<ProjectSelectionPage> {
     );
   }
 
-  Widget _buildEmptyState(
-    BuildContext context,
-    ColorScheme colorScheme,
-    ThemeData theme,
-  ) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 24),
-      child: Column(
-        children: [
-          Icon(
-            Icons.create_new_folder_outlined,
-            size: 56,
-            color: colorScheme.outline,
-          ),
-          verticalSpacing10,
-          Text(
-            context.l10n.project_selection_empty_title,
-            style: theme.textTheme.titleMedium?.copyWith(
-              fontWeight: FontWeight.bold,
-            ),
-          ),
-          heightTen,
-          Text(
-            context.l10n.project_selection_empty_subtitle,
-            textAlign: TextAlign.center,
-            style: theme.textTheme.bodyMedium?.copyWith(
-              color: colorScheme.onSurfaceVariant,
-            ),
-          ),
-          verticalSpacing25,
-          FilledButton.icon(
-            onPressed: () => _openCreateDialog(context),
-            style: FilledButton.styleFrom(
-              padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 14),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(12),
-              ),
-            ),
-            icon: const Icon(Icons.add),
-            label: Text(context.l10n.dialog_project_create_button),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildProjectSelector(
-    BuildContext context,
-    ProjectViewModel vm,
-    ColorScheme colorScheme,
-    ThemeData theme,
-  ) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          context.l10n.project_selection_dropdown_label,
-          style: theme.textTheme.labelLarge?.copyWith(
-            color: colorScheme.onSurfaceVariant,
-          ),
-        ),
-        heightTen,
-        DropdownButtonFormField<Project>(
-          isExpanded: true,
-          itemHeight: null,
-          borderRadius: BorderRadius.circular(16),
-          dropdownColor: colorScheme.surfaceContainerHigh,
-          elevation: 3,
-          initialValue: _selected,
-          decoration: InputDecoration(
-            border: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(12),
-            ),
-            contentPadding: const EdgeInsets.symmetric(
-              horizontal: 16,
-              vertical: 8,
-            ),
-          ),
-          selectedItemBuilder: (context) {
-            return vm.projects.map((project) {
-              return Row(
-                children: [
-                  Expanded(
-                    child: Text.rich(
-                      TextSpan(
-                        text: project.displayName,
-                        style: const TextStyle(fontWeight: FontWeight.w600),
-                        children: [
-                          TextSpan(
-                            text: '  (${project.key})',
-                            style: TextStyle(
-                              fontSize: 13,
-                              fontWeight: FontWeight.normal,
-                              color: colorScheme.onSurfaceVariant,
-                            ),
-                          ),
-                        ],
-                      ),
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ),
-                  if (project.labor)
-                    Container(
-                      margin: const EdgeInsets.only(left: 8),
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 6,
-                        vertical: 2,
-                      ),
-                      decoration: BoxDecoration(
-                        color: colorScheme.tertiaryContainer,
-                        borderRadius: BorderRadius.circular(4),
-                      ),
-                      child: Text(
-                        'LABOR',
-                        style: TextStyle(
-                          fontSize: 9,
-                          fontWeight: FontWeight.bold,
-                          color: colorScheme.onTertiaryContainer,
-                        ),
-                      ),
-                    ),
-                ],
-              );
-            }).toList();
-          },
-          items: vm.projects.map((project) {
-            return DropdownMenuItem<Project>(
-              value: project,
-              child: Padding(
-                padding: const EdgeInsets.symmetric(vertical: 6),
-                child: Row(
-                  children: [
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Text(
-                            project.displayName,
-                            style: const TextStyle(fontWeight: FontWeight.w600),
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                          Text(
-                            project.key,
-                            style: TextStyle(
-                              fontSize: 12,
-                              color: colorScheme.onSurfaceVariant,
-                            ),
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                        ],
-                      ),
-                    ),
-                    if (project.labor)
-                      Container(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 8,
-                          vertical: 2,
-                        ),
-                        decoration: BoxDecoration(
-                          color: colorScheme.tertiaryContainer,
-                          borderRadius: BorderRadius.circular(6),
-                        ),
-                        child: Text(
-                          'LABOR',
-                          style: TextStyle(
-                            fontSize: 10,
-                            fontWeight: FontWeight.bold,
-                            color: colorScheme.onTertiaryContainer,
-                          ),
-                        ),
-                      ),
-                  ],
-                ),
-              ),
-            );
-          }).toList(),
-          onChanged: (newProject) {
-            setState(() {
-              _selected = newProject;
-            });
-          },
-        ),
-        if (_selected?.description != null &&
-            _selected!.description!.isNotEmpty) ...[
-          verticalSpacing10,
-          Container(
-            padding: const EdgeInsets.all(12),
-            decoration: BoxDecoration(
-              color: colorScheme.surfaceContainerHighest.withValues(alpha: 0.5),
-              borderRadius: BorderRadius.circular(8),
-            ),
-            child: Text(
-              _selected!.description!,
-              style: theme.textTheme.bodySmall?.copyWith(
-                color: colorScheme.onSurfaceVariant,
-              ),
-            ),
-          ),
-        ],
-      ],
-    );
-  }
-
   void _openCreateDialog(BuildContext context) {
-    showDialog(
-      context: context,
-      builder: (context) => const CreateProjectDialog(),
-    ).then((created) {
-      if (created is Project) {
-        setState(() {
-          _selected = created;
-        });
+    _openProjectDialog(context, (context) => const CreateProjectDialog());
+  }
+
+  void _openEditDialog(BuildContext context, Project project) {
+    _openProjectDialog(
+      context,
+      (context) => EditProjectDialog(project: project),
+    );
+  }
+
+  void _openProjectDialog(BuildContext context, WidgetBuilder builder) {
+    showDialog<Project>(context: context, builder: builder).then((result) {
+      if (result != null) {
+        setState(() => _selected = result);
       }
     });
   }
 
-  void _proceedWithProject(ProjectViewModel vm) {
-    if (_selected != null) {
-      vm.onSelectProject(_selected!);
-      context.go(NavigationEntry.attributes.route);
-    }
+  void _proceedWithProject(ProjectViewModel vm, Project selected) {
+    vm.onSelectProject(selected);
+    context.go(NavigationEntry.attributes.route);
   }
 }

--- a/lib/feature/settings/rows/project_settings_row.dart
+++ b/lib/feature/settings/rows/project_settings_row.dart
@@ -2,6 +2,7 @@ import 'package:async_redux/async_redux.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:stelaris/api/state/actions/project/project_actions.dart';
 import 'package:stelaris/api/state/app_state.dart';
+import 'package:stelaris/feature/project/badge/project_labor_badge.dart';
 import 'package:stelaris/feature/project/dialog/switch_project_dialog.dart';
 import 'package:stelaris/feature/settings/settings_base_row.dart';
 import 'package:stelaris/feature/settings/settings_item.dart';
@@ -84,24 +85,7 @@ class ProjectSettingsRow extends StatelessWidget {
                           ),
                           if (project.labor) ...[
                             const SizedBox(width: 6),
-                            Container(
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 5,
-                                vertical: 1,
-                              ),
-                              decoration: BoxDecoration(
-                                color: colorScheme.tertiaryContainer,
-                                borderRadius: BorderRadius.circular(4),
-                              ),
-                              child: Text(
-                                'LABOR',
-                                style: TextStyle(
-                                  fontSize: 8,
-                                  fontWeight: FontWeight.bold,
-                                  color: colorScheme.onTertiaryContainer,
-                                ),
-                              ),
-                            ),
+                            const ProjectLaborBadge(fontSize: 8),
                           ],
                         ],
                       ),

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -945,6 +945,30 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Switch project'**
   String get dialog_project_switch_confirm;
+
+  /// No description provided for @dialog_project_edit_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Edit project'**
+  String get dialog_project_edit_title;
+
+  /// No description provided for @dialog_project_edit_button.
+  ///
+  /// In en, this message translates to:
+  /// **'Save'**
+  String get dialog_project_edit_button;
+
+  /// No description provided for @dialog_project_key_readonly_hint.
+  ///
+  /// In en, this message translates to:
+  /// **'Project key cannot be changed after creation'**
+  String get dialog_project_key_readonly_hint;
+
+  /// No description provided for @project_selection_edit_tooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Edit project'**
+  String get project_selection_edit_tooltip;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -455,4 +455,17 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get dialog_project_switch_confirm => 'Switch project';
+
+  @override
+  String get dialog_project_edit_title => 'Edit project';
+
+  @override
+  String get dialog_project_edit_button => 'Save';
+
+  @override
+  String get dialog_project_key_readonly_hint =>
+      'Project key cannot be changed after creation';
+
+  @override
+  String get project_selection_edit_tooltip => 'Edit project';
 }

--- a/lib/l10n/stelaris_en.arb
+++ b/lib/l10n/stelaris_en.arb
@@ -160,5 +160,9 @@
   "settings_misc_switch_project_button": "Switch",
   "dialog_project_switch_title": "Switch project?",
   "dialog_project_switch_hint": "Loaded items, fonts, notifications, attributes and sound events will be reset.",
-  "dialog_project_switch_confirm": "Switch project"
+  "dialog_project_switch_confirm": "Switch project",
+  "dialog_project_edit_title": "Edit project",
+  "dialog_project_edit_button": "Save",
+  "dialog_project_key_readonly_hint": "Project key cannot be changed after creation",
+  "project_selection_edit_tooltip": "Edit project"
 }

--- a/test/feature/project/dialog/project_edit_dialog_test.dart
+++ b/test/feature/project/dialog/project_edit_dialog_test.dart
@@ -1,0 +1,115 @@
+import 'package:async_redux/async_redux.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:stelaris/api/api_service.dart';
+import 'package:stelaris/api/state/app_state.dart';
+import 'package:stelaris/feature/project/dialog/project_edit_dialog.dart';
+import 'package:stelaris/l10n/app_localizations.dart';
+import 'package:stelaris_models/stelaris_models.dart';
+
+import '../../../support/fake_http_client_adapter.dart';
+
+void main() {
+  group('EditProjectDialog Widget Tests', () {
+    const originalProject = Project(
+      id: 'proj-123',
+      displayName: 'Original Project',
+      key: 'orig_key',
+      description: 'Original Description',
+      projectUrl: 'https://github.com/test/repo',
+      docuUrl: 'https://docs.test.com',
+      labor: false,
+    );
+
+    Future<Store<AppState>> pumpDialog(
+      WidgetTester tester, {
+      Project project = originalProject,
+    }) async {
+      final store = Store<AppState>(
+        initialState: AppState(
+          projects: [project],
+          selectedProject: project,
+        ),
+      );
+
+      ApiService().projectApi.apiClient.dio.httpClientAdapter =
+          FakeHttpClientAdapter.json(
+        project.copyWith(displayName: 'Updated Name').toJson(),
+      );
+
+      await tester.pumpWidget(
+        StoreProvider<AppState>(
+          store: store,
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: Builder(
+                builder: (context) => ElevatedButton(
+                  onPressed: () => showDialog(
+                    context: context,
+                    builder: (_) => EditProjectDialog(project: project),
+                  ),
+                  child: const Text('Open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      return store;
+    }
+
+    testWidgets('pre-populates all existing project properties', (tester) async {
+      await pumpDialog(tester);
+
+      expect(find.text('Edit project'), findsOneWidget);
+      expect(find.text('Original Project'), findsOneWidget);
+      expect(find.text('orig_key'), findsOneWidget);
+      expect(find.text('Original Description'), findsOneWidget);
+      expect(find.text('https://github.com/test/repo'), findsOneWidget);
+      expect(find.text('https://docs.test.com'), findsOneWidget);
+      expect(find.byType(SwitchListTile), findsOneWidget);
+    });
+
+    testWidgets('closes when Cancel is pressed', (tester) async {
+      await pumpDialog(tester);
+
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Edit project'), findsNothing);
+    });
+
+    testWidgets('validates required display name and updates project on Save', (
+      tester,
+    ) async {
+      final store = await pumpDialog(tester);
+
+      // Clear display name to trigger validation error
+      final displayNameFinder = find.byType(TextFormField).first;
+      await tester.enterText(displayNameFinder, '');
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Display name is required'), findsOneWidget);
+
+      // Enter valid updated name
+      await tester.enterText(displayNameFinder, 'Updated Name');
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Edit project'), findsNothing);
+      expect(store.state.projects.first.displayName, 'Updated Name');
+      expect(store.state.selectedProject?.displayName, 'Updated Name');
+    });
+  });
+}

--- a/test/feature/project/parts/empty_project_view_test.dart
+++ b/test/feature/project/parts/empty_project_view_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:stelaris/feature/project/parts/empty_project_view.dart';
+import 'package:stelaris/l10n/app_localizations.dart';
+
+void main() {
+  group('EmptyProjectView Widget Tests', () {
+    testWidgets('renders empty state text, icon and create button', (
+      tester,
+    ) async {
+      var createClicked = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: EmptyProjectView(
+              onCreateProject: () => createClicked = true,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('No projects found'), findsOneWidget);
+      expect(
+        find.text('Get started by creating your first project.'),
+        findsOneWidget,
+      );
+      expect(find.byIcon(Icons.create_new_folder_outlined), findsOneWidget);
+      expect(find.text('Create'), findsOneWidget);
+
+      await tester.tap(find.text('Create'));
+      await tester.pumpAndSettle();
+
+      expect(createClicked, isTrue);
+    });
+  });
+}

--- a/test/feature/project/project_app_bar_badge_test.dart
+++ b/test/feature/project/project_app_bar_badge_test.dart
@@ -55,7 +55,7 @@ void main() {
       );
 
       expect(find.text('My Project'), findsOneWidget);
-      expect(find.text('LABOR'), findsOneWidget);
+      expect(find.text('Labor'), findsOneWidget);
       expect(find.byIcon(Icons.folder_outlined), findsOneWidget);
     });
   });

--- a/test/feature/project/project_selection_page_test.dart
+++ b/test/feature/project/project_selection_page_test.dart
@@ -23,6 +23,7 @@ void main() {
         ).toJson((p) => p.toJson()),
       );
     });
+
     testWidgets('renders empty state when no projects exist', (tester) async {
       final store = Store<AppState>(initialState: const AppState());
 
@@ -45,7 +46,62 @@ void main() {
       expect(find.byIcon(Icons.add), findsOneWidget);
     });
 
-    testWidgets('renders dropdown with projects when available', (tester) async {
+    testWidgets('renders list with projects when available', (tester) async {
+      const projectA = Project(
+        id: 'test_id_a',
+        displayName: 'Test Project A',
+        key: 'test_key_a',
+        description: 'First project description',
+      );
+      const projectB = Project(
+        id: 'test_id_b',
+        displayName: 'Test Project B',
+        key: 'test_key_b',
+        description: 'Second project description',
+        labor: true,
+      );
+
+      ApiService().projectApi.apiClient.dio.httpClientAdapter =
+          FakeHttpClientAdapter.json(
+        const PaginatedResult<Project>(
+          items: [projectA, projectB],
+          totalItems: 2,
+          totalPages: 1,
+          currentPage: 1,
+          pageSize: 50,
+        ).toJson((p) => p.toJson()),
+      );
+
+      final store = Store<AppState>(
+        initialState: const AppState(projects: [projectA, projectB]),
+      );
+
+      await tester.pumpWidget(
+        StoreProvider<AppState>(
+          store: store,
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: ProjectSelectionPage(),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(find.text('Welcome to Stelaris'), findsOneWidget);
+      expect(find.text('Select Project'), findsOneWidget);
+      expect(find.text('Test Project A'), findsOneWidget);
+      expect(find.text('Test Project B'), findsOneWidget);
+      expect(find.text('First project description'), findsOneWidget);
+      expect(find.text('Second project description'), findsOneWidget);
+      expect(find.text('Labor'), findsOneWidget);
+      expect(find.text('Open Project'), findsOneWidget);
+      expect(find.byIcon(Icons.add), findsOneWidget);
+      expect(find.byIcon(Icons.edit_outlined), findsNWidgets(2));
+    });
+
+    testWidgets('tapping edit icon opens EditProjectDialog', (tester) async {
       const project = Project(
         id: 'test_id',
         displayName: 'Test Project',
@@ -81,11 +137,11 @@ void main() {
 
       await tester.pumpAndSettle();
 
-      expect(find.text('Welcome to Stelaris'), findsOneWidget);
-      expect(find.text('Select Project'), findsOneWidget);
-      expect(find.textContaining('Test Project'), findsWidgets);
-      expect(find.text('Open Project'), findsOneWidget);
-      expect(find.byIcon(Icons.add), findsOneWidget);
+      await tester.tap(find.byIcon(Icons.edit_outlined));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Edit project'), findsOneWidget);
+      expect(find.text('test_key'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Proposed changes

Currently, a project cannot be edited after its creation. If a type or any other information needs to be changed, the database has to be edited manually. To avoid this, this pull request adds a dialog that allows projects to be edited.

Closes #140 

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [ ] I have read the CONTRIBUTING.md
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)